### PR TITLE
Fix Icon Styling

### DIFF
--- a/source/_templates/partials/head.njk
+++ b/source/_templates/partials/head.njk
@@ -12,7 +12,7 @@
     integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
     crossorigin="anonymous">
 
-  <link rel="stylesheet" href="bootstrap.helix.css">
+  <link rel="stylesheet" href="https://2d2bf231b82dfe76fe36-fa12562cfe810d69bedcc36a0ac289ef.ssl.cf1.rackcdn.com/css/bootstrap.helix.css">
   <link rel="stylesheet" href="helix-ui.css">
   <link rel="stylesheet" href="docs.css">
 

--- a/source/components/icon/HxIcon.less
+++ b/source/components/icon/HxIcon.less
@@ -1,18 +1,7 @@
-:host {
-  background-color: inherit;
-  color: inherit;
-  display: inline-block;
-  height: 1em;
-  width: 1em;
+@import (reference) './hx-icon';
 
-  /*
-    if the requested icon type is not valid (nothing injected),
-    make sure the element doesn't consume space on the page.
-  */
-  &:empty {
-    height: 0;
-    width: 0;
-  }
+:host {
+  &:extend(hx-icon);
 }
 
 ::slotted(svg) {

--- a/source/components/icon/hx-icon.less
+++ b/source/components/icon/hx-icon.less
@@ -1,0 +1,8 @@
+hx-icon {
+  background-color: inherit;
+  color: inherit;
+  display: inline-block;
+  flex-shrink: 0;
+  height: 1em;
+  width: 1em;
+}

--- a/source/helix-ui.less
+++ b/source/helix-ui.less
@@ -19,6 +19,7 @@
 @import 'checkbox/checkbox';
 @import 'code/code';
 @import 'grid/grid';
+@import 'icon/hx-icon';
 @import 'navigation/navigation';
 @import 'reveal/reveal';
 @import 'table/table';


### PR DESCRIPTION
JIRA: n/a

### Correct Restyle of Empty Icon

For polyfilled browsers, before an icon element upgrades, it is empty and has a `0x0 px` dimension. This causes surrounding content to jump around as icons are upgraded (getting proper styles).

BEFORE | AFTER
----- | -----
![icon-empty-before](https://user-images.githubusercontent.com/545605/32632598-d3df703c-c569-11e7-9a92-500561c2e830.gif) | ![icon-empty-after](https://user-images.githubusercontent.com/545605/32632610-e0748468-c569-11e7-85ee-ef0befe313f7.gif)

The `0x0 px` styling (when empty) was removed so that icon elements reserve the space for their SVG images and retain content flow.


### Correct Undesirable Shrinking
An icon defaults to `1x1 em`, which usually computes to `16x16 px`. However, in scenarios where an icon is contained within an element that shrinks for responsiveness, the icon would shrink smaller than `1x1 em`.


### LGTM's
- [x] Dev LGTM
- [x] Design LGTM
- [x] Zoom LGTM
