### PR TITLE
Refactor text inputs

### DIFF
--- a/source/components/text-input/index.html
+++ b/source/components/text-input/index.html
@@ -5,158 +5,95 @@ assets:
 ---
 {% extends 'component.njk' %}
 {% block content %}
+<section>
+  <p>
+    Use the <code>.hxTextCtrl</code> CSS class to apply styles to text-like form controls.
+  </p>
+</section>
 
 <section>
-  <h2 class="hxSectionTitle" id="text">Text</h2>
+  <h2 class="hxSectionTitle" id="single-line-text">Single-Line Text</h2>
   <div class="demo">
-    <form>
-      <div class="hxFormGroup">
-        <label for="txt">Default</label>
-        <input type="text" id="txt" placeholder="Text">
-      </div>
-      <div class="hxFormGroup">
-        <label for="txtInvalid">Invalid</label>
-        <input type="text" class="-hxInvalid" id="txtInvalid" placeholder="Text">
-      </div>
-      <div class="hxFormGroup">
-        <label for="txtDisabled">Disabled</label>
-        <input type="text" id="txtDisabled" placeholder="Text" disabled>
-      </div>
-    </form>
+    <input
+      class="hxTextCtrl"
+      placeholder="Default Text Input"
+      type="text" />
+    <br />
+
+    <input
+      class="hxTextCtrl"
+      invalid
+      placeholder="Invalid Text Input"
+      type="text" />
+    <br />
+
+    <input
+      class="hxTextCtrl"
+      disabled
+      placeholder="Disabled Text Input"
+      type="text" />
   </div>
   {% code 'html' %}
-    <form>
-      <div class="hxFormGroup">
-        <label for="txt">Default</label>
-        <input type="text" id="txt" placeholder="Text">
-      </div>
-      <div class="hxFormGroup">
-        <label for="txtInvalid">Invalid</label>
-        <input type="text" class="-hxInvalid" id="txtInvalid" placeholder="Text">
-      </div>
-      <div class="hxFormGroup">
-        <label for="txtDisabled">Disabled</label>
-        <input type="text" id="txtDisabled" placeholder="Text" disabled>
-      </div>
-    </form>
+    <input
+      class="hxTextCtrl"
+      placeholder="Default Text Input"
+      type="text" />
+
+    <input
+      class="hxTextCtrl"
+      invalid
+      placeholder="Invalid Text Input"
+      type="text" />
+
+    <input
+      class="hxTextCtrl"
+      disabled
+      placeholder="Disabled Text Input"
+      type="text" />
   {% endcode %}
 </section>
 
 <section>
-  <h2 class="hxSectionTitle" id="email">Email</h2>
+  <h2 class="hxSectionTitle" id="multi-line-text">Multi-line Text</h2>
   <div class="demo">
-    <form>
-      <div class="hxFormGroup">
-        <label for="txtEmail">Default</label>
-        <input type="email" id="txtEmail" placeholder="Email">
-      </div>
-      <div class="hxFormGroup">
-        <label for="txtInvalidEmail">Invalid</label>
-        <input type="email" class="-hxInvalid" id="txtInvalidEmail" placeholder="Email">
-      </div>
-      <div class="hxFormGroup">
-        <label for="txtDisabledEmail">Disabled</label>
-        <input type="email" id="txtDisabledEmail" placeholder="Email" disabled>
-      </div>
-    </form>
+    <textarea
+      class="hxTextCtrl"
+      placeholder="Default Text Area"></textarea>
+    <br />
+
+    <textarea
+      class="hxTextCtrl"
+      invalid
+      placeholder="Invalid Text Area"></textarea>
+    <br />
+
+    <textarea
+      class="hxTextCtrl"
+      disabled
+      placeholder="Disabled Text Area"></textarea>
   </div>
   {% code 'html' %}
-    <form>
-      <div class="hxFormGroup">
-        <label for="txtEmail">Default</label>
-        <input type="email" id="txtEmail" placeholder="Email">
-      </div>
-      <div class="hxFormGroup">
-        <label for="txtInvalidEmail">Invalid</label>
-        <input type="email" class="-hxInvalid" id="txtInvalidEmail" placeholder="Email">
-      </div>
-      <div class="hxFormGroup">
-        <label for="txtDisabledEmail">Disabled</label>
-        <input type="email" id="txtDisabledEmail" placeholder="Email" disabled>
-      </div>
-    </form>
+    <textarea
+      class="hxTextCtrl"
+      placeholder="Default Text Area"></textarea>
+
+    <textarea
+      class="hxTextCtrl"
+      invalid
+      placeholder="Invalid Text Area"></textarea>
+
+    <textarea
+      class="hxTextCtrl"
+      disabled
+      placeholder="Disabled Text Area"></textarea>
   {% endcode %}
 </section>
 
 <section>
-  <h2 class="hxSectionTitle" id="password">Password</h2>
-  <div class="demo">
-    <form>
-      <div class="hxFormGroup">
-        <label for="txtPassword">Password</label>
-        <input type="password" id="txtPassword" placeholder="Password">
-      </div>
-      <div class="hxFormGroup">
-        <label for="txtInvalidPassword">Invalid</label>
-        <input type="password" class="-hxInvalid" id="txtInvalidPassword" placeholder="Password">
-      </div>
-      <div class="hxFormGroup">
-        <label for="txtDisabledPassword">Disabled</label>
-        <input type="password" id="txtDisabledPassword" placeholder="Password" disabled>
-      </div>
-    </form>
-  </div>
-  {% code 'html' %}
-    <form>
-      <div class="hxFormGroup">
-        <label for="txtPassword">Password</label>
-        <input type="password" id="txtPassword" placeholder="Password">
-      </div>
-      <div class="hxFormGroup">
-        <label for="txtInvalidPassword">Invalid</label>
-        <input type="password" class="-hxInvalid" id="txtInvalidPassword" placeholder="Password">
-      </div>
-      <div class="hxFormGroup">
-        <label for="txtDisabledPassword">Disabled</label>
-        <input type="password" id="txtDisabledPassword" placeholder="Password" disabled>
-      </div>
-    </form>
-  {% endcode %}
-</section>
-
-<section>
-  <h2 class="hxSectionTitle" id="text-area">Text Area</h2>
-  <div class="demo">
-    <form>
-      <div class="hxFormGroup">
-        <label for="txtArea">Default</label>
-        <textarea rows="3" id="txtArea" placeholder="Enter your comment here"></textarea>
-      </div>
-      <div class="hxFormGroup">
-        <label for="txtAreaInvalid">Invalid</label>
-        <textarea rows="3" class="-hxInvalid" id="txtAreaInvalid" placeholder="Enter your comment here"></textarea>
-      </div>
-      <div class="hxFormGroup">
-        <label for="txtAreaDisabled">Disabled</label>
-        <textarea rows="3" id="txtAreaDisabled" placeholder="Enter your comment here" disabled></textarea>
-      </div>
-    </form>
-  </div>
-  {% code 'html' %}
-    <form>
-      <div class="hxFormGroup">
-        <label for="txtArea">Default</label>
-        <textarea rows="3" id="txtArea" placeholder="Enter your comment here"></textarea>
-      </div>
-      <div class="hxFormGroup">
-        <label for="txtAreaInvalid">Invalid</label>
-        <textarea rows="3" class="-hxInvalid" id="txtAreaInvalid" placeholder="Enter your comment here"></textarea>
-      </div>
-      <div class="hxFormGroup">
-        <label for="txtAreaDisabled">Disabled</label>
-        <textarea rows="3" id="txtAreaDisabled" placeholder="Enter your comment here" disabled></textarea>
-      </div>
-    </form>
-  {% endcode %}
-</section>
-
-<section>
-  <h2 class="hxSectionTitle" id="css-classes">CSS Classes</h2>
-
+  <h2 class="hxSectionTitle" id="attributes">Attributes</h2>
   <dl>
-    <dt><code>.-hxInvalid</code></dt>
-    <dd>Add to form input to apply invalid styling</dd>
+    <dt>invalid (Boolean)</dt>
+    <dd>When present, indicates that a text control is not valid for submission.</dd>
   </dl>
 </section>
-
 {% endblock %}

--- a/source/components/text-input/text-input.less
+++ b/source/components/text-input/text-input.less
@@ -1,5 +1,4 @@
-html input,
-textarea {
+.hxTextCtrl {
   background-color: @gray-0;
   border: 1px solid @gray-500;
   border-radius: 2px;
@@ -9,8 +8,13 @@ textarea {
   padding: 8px;
   width: 100%;
 
+  textarea& {
+    min-height: 5.75rem; // ~92px
+    resize: vertical;
+  }
+
   /*
-  https://css-tricks.com/snippets/css/style-placeholder-text/
+    https://css-tricks.com/snippets/css/style-placeholder-text/
   */
   &::-webkit-input-placeholder { // Chrome
     color: @gray-600;
@@ -25,7 +29,7 @@ textarea {
     color: @gray-600;
   }
 
-  &::placeholder {
+  &::placeholder { // w3c spec
     color: @gray-600;
   }
 
@@ -38,7 +42,7 @@ textarea {
     }
   }
 
-  &.-hxInvalid {
+  &[invalid] {
     border: 2px solid @red-900;
   }
 
@@ -47,14 +51,6 @@ textarea {
     border-color: @gray-300;
     color: @gray-400;
     cursor: not-allowed;
+    resize: none;
   }
-}
-
-textarea[disabled] {
-  resize: none;
-}
-
-// TODO: move to appropriate file
-.hxFormGroup {
-  margin-bottom: 1rem;
 }


### PR DESCRIPTION
JIRA: n/a

* Update Text Inputs component to behave in an additive manner rather than overwriting non-Helix styles (i.e. convert to CSS class).
* Simplify demo
* tweak styles for `textarea`

### LGTM's
- [x] Dev LGTM
- [x] Design LGTM
- [x] Zoom LGTM


### Before
![textinput-before](https://user-images.githubusercontent.com/545605/32802635-432e9208-c946-11e7-8cab-1a28d3a850b4.png)

### After
![textinput-after](https://user-images.githubusercontent.com/545605/32802638-46a39550-c946-11e7-9662-35a7985570ee.png)
