### PR TITLE
fix(CSS): correct style inheritance with <slot>

### DIFF
--- a/source/_less/reset.less
+++ b/source/_less/reset.less
@@ -21,6 +21,10 @@ html {
   box-sizing: inherit;
 }
 
+[hidden] {
+  display: none;
+}
+
 a {
   background-color: transparent;
 }

--- a/source/components/HxElement.less
+++ b/source/components/HxElement.less
@@ -1,0 +1,12 @@
+@import (reference) "vars";
+
+* {
+  box-sizing: border-box;
+
+  // Text styles need passed through
+  color: inherit;
+  font-family: inherit;
+  font-size: inherit;
+  letter-spacing: inherit;
+  line-height: inherit;
+}

--- a/source/components/checkbox/HxCheckbox.less
+++ b/source/components/checkbox/HxCheckbox.less
@@ -1,4 +1,4 @@
-@import 'vars';
+@import "../HxElement";
 
 :host {
   background-color: @gray-0;
@@ -11,10 +11,6 @@
   height: 1rem;
   vertical-align: middle;
   width: 1rem;
-
-  &([hidden]) {
-    display: none;
-  }
 
   /* default unchecked */
   &(:hover) {

--- a/source/components/reveal/HxReveal.html
+++ b/source/components/reveal/HxReveal.html
@@ -1,6 +1,4 @@
 <button id="toggle" aria-expanded="false">
   <slot name="summary"></slot>
 </button>
-<div id="content">
-  <slot></slot>
-</div>
+<slot id="content"></slot>

--- a/source/components/reveal/HxReveal.less
+++ b/source/components/reveal/HxReveal.less
@@ -1,8 +1,10 @@
+@import "../HxElement";
+
 :host {
   display: block;
 
-  &([open]) > #content {
-    display: block;
+  &([open]) #content {
+    display: contents;
   }
 }
 
@@ -13,8 +15,6 @@
 #toggle {
   background-color: transparent;
   border: none;
-  color: inherit;
-  font-size: 1em;
   margin: 0;
   padding: 0;
   text-align: left;

--- a/source/components/tabset/HxTabpanel.less
+++ b/source/components/tabset/HxTabpanel.less
@@ -1,4 +1,3 @@
-@import (reference) 'vars';
 @import '../reveal/HxReveal.less';
 
 :host {

--- a/source/components/tabset/HxTabset.less
+++ b/source/components/tabset/HxTabset.less
@@ -1,3 +1,5 @@
+@import "../HxElement";
+
 :host {
   background-color: inherit;
   display: block;

--- a/source/components/tabset/index.html
+++ b/source/components/tabset/index.html
@@ -18,9 +18,23 @@ assets:
       <a href="#" role="tab" class="hxTab">Caramels Marzipan</a>
     </div>
     <hx-tabpanel id="cupcake">
-      <p>
-        Cupcake ipsum dolor sit amet pie. Tiramisu icing cake. Macaroon halvah apple pie. Carrot cake cheesecake chocolate bar toffee biscuit candy gummi bears. Apple pie chocolate cake dessert liquorice biscuit cupcake. Jelly sugar plum chocolate bar chocolate. Wafer fruitcake carrot cake jelly jujubes cookie danish. Sesame snaps gingerbread gingerbread pastry gummies jelly beans icing. Sesame snaps wafer lollipop. Cookie gummies icing marshmallow powder soufflé topping tart.
-      </p>
+      <div class="hxRow">
+        <div class="hxCol-6">
+          <p>
+            Cupcake ipsum dolor sit amet bonbon topping caramels. Sesame snaps
+            gummi bears liquorice cookie chupa chups fruitcake croissant
+            chocolate topping. Brownie biscuit wafer marshmallow liquorice
+            soufflé powder jelly.
+          </p>
+        </div>
+        <div class="hxCol-6">
+          <p>
+            Sweet roll sesame snaps danish I love jelly wafer dragée soufflé
+            cake. Cookie chocolate cake gingerbread powder icing. Ice cream
+            cotton candy gummi bears oat cake sweet pastry.
+          </p>
+        </div>
+      </div>
     </hx-tabpanel>
     <hx-tabpanel id="biscuit">
       <p>
@@ -41,7 +55,12 @@ assets:
       <a href="#" role="tab" class="hxTab">Biscuit Marshmallow</a>
       <a href="#" role="tab" class="hxTab">Caramel Marzipan</a>
     </div>
-    <hx-tabpanel id="cupcake">...</hx-tabpanel>
+    <hx-tabpanel id="cupcake">
+      <div class="hxRow">
+        <div class="hxCol-6">...</div>
+        <div class="hxCol-6">...</div>
+      </div>
+    </hx-tabpanel>
     <hx-tabpanel id="biscuit">...</hx-tabpanel>
     <hx-tabpanel id="caramel">...</hx-tabpanel>
   </hx-tabset>

--- a/source/docs.less
+++ b/source/docs.less
@@ -12,7 +12,7 @@
   -------------------------
   For distributed HelixUI CSS styles, see source/styles/helix-ui.less
 */
-@import 'vars';
+@import (reference) 'vars';
 
 body {
   background-color: @gray-25;

--- a/source/helix-ui.less
+++ b/source/helix-ui.less
@@ -4,8 +4,8 @@
 @import 'imports';
 
 // LESS Vars and Mixins
-@import (less, reference) 'vars';
-@import (less, reference) 'mixins';
+@import (reference) 'vars';
+@import (reference) 'mixins';
 
 // Normalization and Resets
 @import  'reset';


### PR DESCRIPTION
Correct styling bug. This bug isn't present in polyfilled browsers.

CSS inheritance includes the `<slot>` element in the Shadow DOM (See [Slots and Slotted Elements in a Shadow Tree](https://drafts.csswg.org/css-scoping/#slots-in-shadow-tree)). As such, several css properties that we thought we're being inherited from the light DOM are incorrect. To correct, I've set up a generic `HxElement.less` file that will handle common resets needed to build custom elements.

### LGTM's
- [x] Dev LGTM
- [x] Zoom LGTM

### BEFORE
_The two paragraphs in the tab should share half the width._
![tabset-before](https://user-images.githubusercontent.com/545605/32866876-812949d8-ca2f-11e7-8bb3-4414095a0914.png)

### AFTER
![tabset-after](https://user-images.githubusercontent.com/545605/32866908-af853634-ca2f-11e7-8cd5-60485a0008b7.png)
