### PR TITLE
refactor(Tabset): refactor and add functionality

### DIFF
--- a/source/components/tabset/HxTabpanel.less
+++ b/source/components/tabset/HxTabpanel.less
@@ -1,14 +1,5 @@
 @import '../reveal/HxReveal.less';
 
-:host {
-  &([open]) {
-    border-color: @gray-300 transparent;
-    border-style: solid;
-    border-width: 1px;
-    padding: 1.5rem 1.25rem;
-  }
-}
-
 #toggle {
   display: none;
 }

--- a/source/components/tabset/HxTabset.html
+++ b/source/components/tabset/HxTabset.html
@@ -1,6 +1,8 @@
-<div id ="head">
-  <slot name="tabs"></slot>
-</div>
-<div id ="body">
-  <slot></slot>
+<div id="wrapper">
+  <div id="head">
+    <slot name="tabs"></slot>
+  </div>
+  <div id="body">
+    <slot></slot>
+  </div>
 </div>

--- a/source/components/tabset/HxTabset.less
+++ b/source/components/tabset/HxTabset.less
@@ -1,15 +1,27 @@
 @import "../HxElement";
+@import (reference) "./hx-tabset";
 
 :host {
+  &:extend(hx-tabset);
   background-color: inherit;
-  display: block;
 }
 
-slot {
-  // Because Safari
+#wrapper {
   background-color: inherit;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 }
 
 #head {
   background-color: inherit;
+  flex-shrink: 0;
+}
+
+#body {
+  background-color: inherit;
+  flex-grow: 1;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding: 1.5rem 1.25rem;
 }

--- a/source/components/tabset/hx-tabset.less
+++ b/source/components/tabset/hx-tabset.less
@@ -1,0 +1,3 @@
+hx-tabset {
+  display: block;
+}

--- a/source/components/tabset/index.html
+++ b/source/components/tabset/index.html
@@ -10,7 +10,7 @@ assets:
 
 <section>
 <h2 class="hxSectionTitle" id="tabset">Tabset</h2>
-<div class="demo">
+<div class="demo demo-tabset">
   <hx-tabset>
     <div slot="tabs">
       <a href="#" role="tab" class="hxTab">Cupcake Ipsum</a>
@@ -38,7 +38,42 @@ assets:
     </hx-tabpanel>
     <hx-tabpanel id="biscuit">
       <p>
-        Biscuit marshmallow chocolate cake tiramisu cupcake. Powder liquorice jelly cheesecake chocolate bar. Chocolate cake icing pudding. Tart ice cream cupcake. Cake chocolate bar carrot cake pie marshmallow sugar plum dessert. Pudding lollipop sugar plum topping sugar plum chocolate bar jelly-o pastry donut. Candy canes icing apple pie pie.
+        Cupcake ipsum dolor. Sit amet soufflé croissant topping cotton candy.
+        Chocolate cake candy bear claw sweet roll tootsie roll apple pie
+        halvah marshmallow. Dragée lemon drops cake gingerbread chocolate.
+        Jujubes croissant sesame snaps oat cake tiramisu jujubes brownie.
+        Candy canes fruitcake chocolate cake topping. Pudding gummi bears
+        candy. Sweet soufflé macaroon tiramisu fruitcake. Sugar plum biscuit
+        chocolate bar dessert sesame snaps carrot cake candy canes gummies.
+        Sugar plum macaroon chocolate cake gummies chupa chups cupcake tootsie
+        roll. Candy canes tootsie roll tootsie roll tart chocolate lemon drops
+        cake danish chocolate cake. Chocolate jelly tart lemon drops chocolate
+        bar fruitcake candy canes marzipan chupa chups. Cake chupa chups sweet
+        macaroon tootsie roll cupcake tootsie roll.
+      </p>
+      <p>
+        Bear claw sweet roll topping. Danish cake powder muffin pastry. Bonbon
+        cake marzipan oat cake bear claw cookie. Cake icing jelly beans sugar
+        plum cheesecake tootsie roll marzipan. Powder donut halvah danish
+        gingerbread gummies chocolate candy. Donut wafer topping caramels
+        bonbon cake halvah pudding cupcake. Ice cream powder chocolate cake
+        chupa chups chocolate cake. Jujubes caramels sesame snaps cotton candy
+        sesame snaps caramels. Marshmallow bonbon bear claw candy canes
+        cheesecake cupcake. Gummies soufflé apple pie. Gummi bears tart
+        chocolate croissant cupcake. Bear claw biscuit oat cake gummies
+        fruitcake brownie. Marzipan jujubes carrot cake.
+      </p>
+      <p>
+        Jelly beans carrot cake oat cake. Toffee dessert macaroon candy bear
+        claw. Muffin pudding carrot cake lollipop biscuit lollipop cake wafer.
+        Bonbon lemon drops candy pie jelly-o candy canes sweet. Jelly-o
+        chocolate bar pie croissant ice cream. Sweet ice cream gummi bears
+        sweet soufflé ice cream donut soufflé croissant. Jujubes dessert danish
+        jelly beans liquorice sweet roll sweet fruitcake wafer. Tootsie roll
+        jelly-o halvah. Cotton candy lollipop chocolate cake macaroon toffee
+        cookie brownie. Dessert cheesecake chocolate cake chocolate bonbon
+        jelly-o lemon drops. Jujubes sesame snaps dessert lollipop carrot cake.
+        Caramels pie candy sesame snaps chocolate bar chocolate cake.
       </p>
     </hx-tabpanel>
     <hx-tabpanel id="caramel">

--- a/source/components/tabset/tabset-docs.less
+++ b/source/components/tabset/tabset-docs.less
@@ -1,0 +1,5 @@
+.demo-tabset {
+  hx-tabset {
+    height: 300px;
+  }
+}

--- a/source/components/tabset/tabset.less
+++ b/source/components/tabset/tabset.less
@@ -1,8 +1,11 @@
+@import "./hx-tabset";
+
 hx-tabset {
-  display: block;
+  border-bottom: 1px solid @gray-300;
 
   [slot="tabs"] {
     background-color: inherit;
+    border-bottom: 1px solid @gray-300;
   }
 
   .hxTab {
@@ -28,15 +31,15 @@ hx-tabset {
       color: @cyan-700;
     }
 
+    &:focus {
+      text-decoration: none;
+    }
+
     &.current {
       background-color: inherit;
       border-color: @gray-300 @gray-300 transparent;
       color: @cyan-900;
     }
-  }
-
-  hx-tabpanel {
-    min-height: 172px; //min height
   }
 
   hx-tabpanel:not([open]) {

--- a/source/docs.less
+++ b/source/docs.less
@@ -82,6 +82,7 @@ main {
 @import 'grid/grid-docs';
 @import 'icon/icon-docs';
 @import 'popover/popover-docs';
+@import 'tabset/tabset-docs';
 @import 'tooltip/tooltip-docs';
 @import 'typography/typography-docs';
 


### PR DESCRIPTION
* FIX: tab text decoration removed when focused
* FEAT: scroll tabset body when element is vertically constrained

JIRA: (part of) https://jira.rax.io/browse/SURF-623

### LGTM's
- [ ] Dev LGTM
- [ ] Design LGTM
- [ ] Zoom LGTM

### Before
_Tab contents overflow when tabset height is constrained._
![tabset-before](https://user-images.githubusercontent.com/545605/32969417-af623eb4-cbaa-11e7-8481-02c686136d0e.png)

### After
![scrolling-tabs](https://user-images.githubusercontent.com/545605/32969531-1d0c13d6-cbab-11e7-8d3d-5c382b5f09d3.gif)

_Verified working in IE11_
<img width="901" alt="screen shot 2017-11-17 at 3 24 57 pm" src="https://user-images.githubusercontent.com/545605/32969648-8a6672aa-cbab-11e7-8d11-b5fc80a40cec.png">
