### PR TITLE
SURF-623: Modify Grid

### DIFF
--- a/bin/start.js
+++ b/bin/start.js
@@ -35,16 +35,6 @@ browserSync.init({
             ],
             fn: () => {
                 Build.buildSync();
-
-                /**
-                 * Always ensure that this task runs last, as it needs to wait for all
-                 * synchronous build events to complete so that browserSync can finish
-                 * and reload the page (and therefore, allow selenium to connnect).
-                 */
-                const tests = exec('yarn run test:regression -u', { cwd: CONFIG.testDir });
-                // this *is* asynchronous, see comment above
-                tests.stdout.pipe(process.stdout);
-                tests.stderr.pipe(process.stderr);
             }
         },
 

--- a/source/_templates/component.njk
+++ b/source/_templates/component.njk
@@ -7,10 +7,10 @@
     </h1>
 
     <div class="hxRow">
-      <div class="hxCol-xs-12 hxCol-md-3 hxOrder-md-2">
+      <div class="hxCol hxSpan-12-xs hxSpan-3-md hxOrder-2-md">
         {% include 'partials/sidebar.njk' %}
       </div>
-      <div class="hxCol-xs-12 hxCol-md-9 hxOrder-1">
+      <div class="hxCol hxSpan-12-xs hxSpan-9-md hxOrder-1-md">
         {% block content %}
           {# page content goes here #}
         {% endblock %}

--- a/source/components/grid/grid-docs.less
+++ b/source/components/grid/grid-docs.less
@@ -3,34 +3,27 @@
     border: 1px dotted @gray-400;
   }
 
-  .hxCol,
-  [class*="hxCol-"] {
+  .hxCol {
     background-clip: content-box;
     background-color: fade(@green-500, 25%);
     font-size: 0.75rem;
   }
 }
 
-.drop-cap {
-  p::first-letter {
-    font-size: 2em;
-    font-weight: 700;
-  }
-}
-
 // Automatically Set Column Content based on breakpoint (lg-2, md-8, etc.)
-.demoColumns (@prefix, @n) when (@n > 0) and (@prefix = xs) {
-  .demoCol.hxCol-@{n}::before {
-    content: '@{prefix}-@{n}';
+.demoColumns (@size, @n) when (@n > 0) and (@size = xs) {
+  .demoCol.hxSpan-@{n}-xs::before,
+  .demoCol.hxSpan-@{n}::before {
+    content: '@{n}-@{size}';
   }
-  .demoColumns(@prefix, @n - 1);
-}//.demoColumns()
-.demoColumns (@prefix, @n) when (@n > 0) and not (@prefix = xs) {
-  .demoCol.hxCol-@{prefix}-@{n}::before {
-    content: '@{prefix}-@{n}';
+  .demoColumns(@size, @n - 1);
+}
+.demoColumns (@size, @n) when (@n > 0) and not (@size = xs) {
+  .demoCol.hxSpan-@{n}-@{size}::before {
+    content: '@{n}-@{size}';
   }
-  .demoColumns(@prefix, @n - 1);
-}//.demoColumns()
+  .demoColumns(@size, @n - 1);
+}
 
 @media (min-width: @grid-break-wrist) {
   #querySize::before {
@@ -70,7 +63,7 @@
   .demoColumns(xl, @grid-column-count);
 }
 
-.styled-container {
+.example-styled-container {
   background-color: @cyan-100;
   border-radius: 0;
   border: 1px solid @cyan-500;

--- a/source/components/grid/grid.less
+++ b/source/components/grid/grid.less
@@ -1,73 +1,83 @@
+// GRID CONFIG
+@col-padding: (@grid-gutter-size * 0.5);
+@row-margin: -(@col-padding);
+
 // ----- GRID MIXINS ----- //
-//e.g. .hxCol-1, .hxCol-md-8, .hxCol-lg-12
-.make-grid-columns (@prefix, @n) when (@n > 0) and (@prefix = xs) {
-  .hxCol-@{prefix}-@{n},
-  .hxCol-@{n} {
-    @width: (@n * @grid-column-unit);
-    flex: 0 0 @width;
-    max-width: @width;
+#grid {
+  .span(@n) {
+    @basis: (@n * @grid-column-unit);
+    flex: 0 0 @basis;
+    max-width: @basis;
   }
-  .make-grid-columns(@prefix, (@n - 1));
+
+  .offset(@n) {
+    margin-left: (@n * @grid-column-unit) !important;
+  }
+}//#grid
+
+
+// hxCol-{N}-xs
+// hxCol-{N}
+.make-grid-columns (@size, @n) when (@n > 0) and (@size = xs) {
+  .hxSpan-@{n}-@{size},
+  .hxSpan-@{n} {
+    #grid.span(@n);
+  }
+  .make-grid-columns(@size, (@n - 1));
 }
-.make-grid-columns (@prefix, @n) when (@n > 0) and not (@prefix = xs) {
-  .hxCol-@{prefix}-@{n} {
-    @width: (@n * @grid-column-unit);
-    flex: 0 0 @width;
-    max-width: @width;
+// hxCol-{N}-{size}
+.make-grid-columns (@size, @n) when (@n > 0) and not (@size = xs) {
+  .hxSpan-@{n}-@{size} {
+    #grid.span(@n);
   }
-  .make-grid-columns(@prefix, (@n - 1));
+  .make-grid-columns(@size, (@n - 1));
 }
 
-//e.g. .hxOffset-1, .hxOffset-md-3, .hxOffset-lg-0
-.make-grid-offsets (@prefix, @n) when (@n >= 0) and (@prefix = xs) {
-  .hxOffset-@{prefix}-@{n},
+// hxOffset-{N}-xs
+// hxOffset-{N}
+.make-grid-offsets (@size, @n) when (@n > 0) and (@size = xs) {
+  .hxOffset-@{n}-@{size},
   .hxOffset-@{n} {
-    margin-left: (@n * @grid-column-unit) !important;
+    #grid.offset(@n);
   }
-  .make-grid-offsets(@prefix, (@n - 1));
+  .make-grid-offsets(@size, (@n - 1));
 }
-.make-grid-offsets (@prefix, @n) when (@n >= 0) and not (@prefix = xs) {
-  .hxOffset-@{prefix}-@{n} {
-    margin-left: (@n * @grid-column-unit) !important;
+// hxOffset-{N}-{size}
+.make-grid-offsets (@size, @n) when (@n > 0) and not (@size = xs) {
+  .hxOffset-@{n}-@{size} {
+    #grid.offset(@n);
   }
-  .make-grid-offsets(@prefix, (@n - 1));
+  .make-grid-offsets(@size, (@n - 1));
 }
 
-//e.g. .hxOrder-1, .hxOrder-md-4
-.make-grid-orders (@prefix, @n) when (@n > 0) and (@prefix = xs) {
-  .hxOrder-@{prefix}-@{n},
+// hxOrder-{N}-xs
+// hxOrder-{N}
+.make-grid-orders (@size, @n) when (@n > 0) and (@size = xs) {
+  .hxOrder-@{n}-@{size},
   .hxOrder-@{n} {
     order: @n;
   }
-  .make-grid-orders(@prefix, (@n - 1));
+  .make-grid-orders(@size, (@n - 1));
 }
-.make-grid-orders (@prefix, @n) when (@n > 0) and not (@prefix = xs) {
-  .hxOrder-@{prefix}-@{n} {
+// hxOrder-{N}-{size}
+.make-grid-orders (@size, @n) when (@n > 0) and not (@size = xs) {
+  .hxOrder-@{n}-@{size} {
     order: @n;
   }
-  .make-grid-orders(@prefix, (@n - 1));
+  .make-grid-orders(@size, (@n - 1));
 }
 
-.make-grid (@prefix) {
+.make-grid (@size) {
   // 1 to N
-  .make-grid-columns(@prefix, @grid-column-count);
+  .make-grid-columns(@size, @grid-column-count);
   // 0 to N
-  .make-grid-offsets(@prefix, @grid-column-count);
+  .make-grid-offsets(@size, @grid-column-count);
   // 1 to N
-  .make-grid-orders(@prefix, @grid-column-count);
+  .make-grid-orders(@size, @grid-column-count);
 }
 //end:mixins
 
 /* ===== GRID ===== */
-@col-padding: (@grid-gutter-size * 0.5);
-@row-margin: -(@col-padding);
-
-.hxCol,
-[class*="hxCol-"] {
-  display: flex;
-  flex-direction: column;
-  flex-grow: 1;
-}
 .hxRow {
   border: 0;
   display: flex;
@@ -79,21 +89,22 @@
     margin-top: @grid-gutter-size;
   }
 
-  .hxCol,
-  [class*="hxCol-"] {
-    padding: 0 @col-padding;
+  & > .hxCol {
+    flex-grow: 1;
     margin: 0 0 @grid-gutter-size;
+    padding: 0 @col-padding;
   }
 
-  &.no-gutters {
-    margin-left: 0;
-    margin-right: 0;
+  &.hxGutterless {
+    margin: 0;
 
-    .hxCol,
-    [class*="hxCol-"] {
+    & > .hxRow + .hxRow {
+      margin-top: 0;
+    }
+
+    & > .hxCol {
       margin: 0;
-      padding-left: 0;
-      padding-right: 0;
+      padding: 0;
     }
   }
 }

--- a/source/components/grid/index.html
+++ b/source/components/grid/index.html
@@ -5,52 +5,73 @@ assets:
 ---
 {% extends 'component.njk' %}
 {% block content %}
-<h2 class="hxSectionTitle">12-column Grid</h2>
-<p>
-  The grid system requires loading <code>helix-ui.css</code> into your application.
-</p>
-
 <section>
-  <h3 class="hxSubSectionTitle" id="bootstrap">Bootstrap Compatibility</h3>
-  <ol>
-    <li>
-      <b>Avoid using Bootstrap containers</b>
-      <ul>
-        <li>
-          The Bootstrap <code>.container</code> class will cause an
-          <code>.hxRow</code> to expand beyond what is expected.
-        </li>
-      </ul>
-    </li>
-    <li>
-      <b>Please use the Bootstrap grid with Bootstrap form classes.</b>
-      <ul>
-        <li>
-          The <code>.form-section</code>, <code>.form-control</code>, and other form-related
-          Bootstrap CSS classes are known to have compatibility issues with the HelixUI grid.
-        </li>
-      </ul>
-    </li>
-  </ol>
-</section>
-
-<section>
-  <h3 class="hxSubSectionTitle" id="automatic">Automatic Columns</h3>
-  <div class="hxAlert">
+  <div class="hxAlert hxAlert--warning">
     <div class="hxAlert__icon">
-      <hx-icon type="info-circle"></hx-icon>
+      <hx-icon type="exclamation-triangle"></hx-icon>
     </div>
     <div class="hxAlert__text">
-      <span class="hxAlert__status">NOTE</span>
-      Automatic columns are overridden by <a href="#responsive">responsive classes</a>.
+      <span class="hxAlert__status">Warning</span>
+      HelixUI grid classes are not compatible with Bootstrap grid styles.
     </div>
   </div>
   <br />
 
   <p>
-    Automatic columns will share row width equally among other automatic columns.
+    The Grid CSS module provides utility classes based on flexbox to help
+    with the positioning and layout of content within containers.
   </p>
+</section>
 
+<section><!-- rows -->
+  <h2 class="hxSectionTitle" id="rows">Rows</h2>
+  <ul>
+    <li>
+      Rows are containers that allow you to divide their
+      <em>width</em> amongst their children.
+    </li>
+  </ul>
+
+  <div class="demo grid-demo">
+    <p>
+      It was discovered that by rarely reviewing the VOC meetings, we can
+      practice the ranked XP task for the agile branch. If it takes you too
+      long to join the viable XP manifesto, then you are not burning out enough.
+    </p>
+    <div class="hxRow">
+      <div class="hxCol"><p>Column 1 of 3</p></div>
+      <div class="hxCol"><p>Column 2 of 3</p></div>
+      <div class="hxCol"><p>Column 3 of 3</p></div>
+    </div>
+    <p>
+      Try to commit the burndown standard, maybe it will help join the MVP
+      standards. As a user, I should be able to block the burndown deadline so
+      that I can block the minimum WIP methods near the parallel deadlines.
+    </p>
+  </div>
+  {% code 'html' %}
+    <p>...</p>
+    <div class="hxRow">
+      <div class="hxCol"><p>Column 1 of 3</p></div>
+      <div class="hxCol"><p>Column 2 of 3</p></div>
+      <div class="hxCol"><p>Column 3 of 3</p></div>
+    </div>
+    <p>...</p>
+  {% endcode %}
+</section>
+
+<section><!-- columns -->
+  <h2 class="hxSectionTitle" id="columns">Columns</h2>
+  <ul>
+    <li>
+      Columns are containers that allow you to divide their
+      <em>height</em> amongst their children.
+    </li>
+    <li>Columns are the basis for all positioned content within a row.</li>
+    <li>
+      Columns <em>share width equally</em> among other columns in the same row.
+    </li>
+  </ul>
   <div class="demo grid-demo">
     <div class="demo-container text-center">
       <div class="hxRow">
@@ -58,310 +79,189 @@ assets:
       </div>
       <div class="hxRow">
         <div class="hxCol">1/2</div>
-        <div class="hxCol">1/2</div>
+        <div class="hxCol">2/2</div>
       </div>
       <div class="hxRow">
         <div class="hxCol">1/3</div>
-        <div class="hxCol">1/3</div>
-        <div class="hxCol">1/3</div>
-      </div>
-      <div class="hxRow">
-        <div class="hxCol">1/4</div>
-        <div class="hxCol">1/4</div>
-        <div class="hxCol">1/4</div>
-        <div class="hxCol">1/4</div>
+        <div class="hxCol">2/3</div>
+        <div class="hxCol">3/3</div>
       </div>
     </div>
   </div>
-
   {% code 'html' %}
     <div class="hxRow">
       <div class="hxCol">1/1</div>
     </div>
     <div class="hxRow">
       <div class="hxCol">1/2</div>
-      <div class="hxCol">1/2</div>
+      <div class="hxCol">2/2</div>
     </div>
     <div class="hxRow">
       <div class="hxCol">1/3</div>
-      <div class="hxCol">1/3</div>
-      <div class="hxCol">1/3</div>
-    </div>
-    <div class="hxRow">
-      <div class="hxCol">1/4</div>
-      <div class="hxCol">1/4</div>
-      <div class="hxCol">1/4</div>
-      <div class="hxCol">1/4</div>
+      <div class="hxCol">2/3</div>
+      <div class="hxCol">3/3</div>
     </div>
   {% endcode %}
 </section>
 
-<section>
-  <h3 class="hxSubSectionTitle" id="explicit">Explicit Columns</h3>
+<section><!-- column width -->
+  <h2 class="hxSectionTitle" id="column-width">Column Width</h2>
+  <p>
+    Column width modifiers will set the width of a column container to a
+    predefined percentage of the row width.
+  </p>
+  <p>
+    Use the <code>.hxSpan-{N}</code> modifier (1 &le; N &le; 12) to create
+    columns that are a fraction of a 12-column row width.
+  </p>
+  <ul>
+    <li><code>.hxSpan-{N}-{size}</code> responsive classes are available.</li>
+    <li><code>.hxSpan-{N}</code> is shorthand for <code>.hxSpan-{N}-xs</code></li>
+  </ul>
+
+  <div class="demo grid-demo">
+    <div class="demo-container text-center">
+      <div class="hxRow">
+        <div class="hxCol hxSpan-12">12</div>
+      </div>
+      <div class="hxRow">
+        <div class="hxCol hxSpan-1">1</div>
+        <div class="hxCol hxSpan-11">11</div>
+      </div>
+      <div class="hxRow">
+        <div class="hxCol hxSpan-2">2</div>
+        <div class="hxCol hxSpan-10">10</div>
+      </div>
+      <div class="hxRow">
+        <div class="hxCol hxSpan-3">3</div>
+        <div class="hxCol hxSpan-9">9</div>
+      </div>
+      <div class="hxRow">
+        <div class="hxCol hxSpan-4">4</div>
+        <div class="hxCol hxSpan-8">8</div>
+      </div>
+      <div class="hxRow">
+        <div class="hxCol hxSpan-5">5</div>
+        <div class="hxCol hxSpan-7">7</div>
+      </div>
+      <div class="hxRow">
+        <div class="hxCol hxSpan-6">6</div>
+        <div class="hxCol hxSpan-6">6</div>
+      </div>
+    </div>
+  </div>
+  {% code 'html' %}
+    <div class="hxRow">
+      <div class="hxCol hxSpan-12">12</div>
+    </div>
+    <div class="hxRow">
+      <div class="hxCol hxSpan-1">1</div>
+      <div class="hxCol hxSpan-11">11</div>
+    </div>
+    <div class="hxRow">
+      <div class="hxCol hxSpan-2">2</div>
+      <div class="hxCol hxSpan-10">10</div>
+    </div>
+    <div class="hxRow">
+      <div class="hxCol hxSpan-3">3</div>
+      <div class="hxCol hxSpan-9">9</div>
+    </div>
+    <div class="hxRow">
+      <div class="hxCol hxSpan-4">4</div>
+      <div class="hxCol hxSpan-8">8</div>
+    </div>
+    <div class="hxRow">
+      <div class="hxCol hxSpan-5">5</div>
+      <div class="hxCol hxSpan-7">7</div>
+    </div>
+    <div class="hxRow">
+      <div class="hxCol hxSpan-6">6</div>
+      <div class="hxCol hxSpan-6">6</div>
+    </div>
+  {% endcode %}
+</section>
+
+<section><!-- column offset -->
+  <h2 class="hxSectionTitle" id="column-offset">Column Offset</h2>
+  <p>
+    You can use the <code>.hxOffset-{N}</code> class (1 &le; N &le; 11)
+    to offset your column from the start of the row.
+  </p>
+  <ul>
+    <li>
+      <code>.hxOffset-{N}-{size}</code> responsive classes are available
+    </li>
+    <li>
+      <code>.hxOffset-{N}</code> is shorthand for <code>.hxOffset-{N}-xs</code>
+    </li>
+  </ul>
+
+  <div class="demo grid-demo">
+    <div class="demo-container text-center">
+      <div class="hxRow">
+        <div class="hxCol hxSpan-2">2</div>
+        <div class="hxCol hxSpan-6 hxOffset-1">6</div>
+        <div class="hxCol hxSpan-2 hxOffset-1">2</div>
+      </div>
+      <div class="hxRow">
+        <div class="hxCol hxSpan-2 hxOffset-2">2</div>
+        <div class="hxCol hxSpan-4">4</div>
+        <div class="hxCol hxSpan-2">2</div>
+      </div>
+      <div class="hxRow">
+        <div class="hxCol hxSpan-4">4</div>
+        <div class="hxCol hxSpan-4 hxOffset-4">4</div>
+      </div>
+    </div>
+  </div>
+  {% code 'html' %}
+    <div class="hxRow">
+      <div class="hxCol hxSpan-2">2</div>
+      <div class="hxCol hxSpan-6 hxOffset-1">6</div>
+      <div class="hxCol hxSpan-2 hxOffset-1">2</div>
+    </div>
+    <div class="hxRow">
+      <div class="hxCol hxSpan-2 hxOffset-2">2</div>
+      <div class="hxCol hxSpan-4">4</div>
+      <div class="hxCol hxSpan-2">2</div>
+    </div>
+    <div class="hxRow">
+      <div class="hxCol hxSpan-4">4</div>
+      <div class="hxCol hxSpan-4 hxOffset-4">4</div>
+    </div>
+  {% endcode %}
+</section>
+
+<section><!-- column ordering -->
+  <h2 class="hxSectionTitle" id="column-ordering">Column Ordering</h2>
   <div class="hxAlert">
     <div class="hxAlert__icon">
       <hx-icon type="info-circle"></hx-icon>
     </div>
     <div class="hxAlert__text">
-      <span class="hxAlert__status">NOTE</span>
-      If the sum of a row's columns exceeds 12, the columns will wrap.<br />
-      See <a href="#wrapping">Column Wrapping</a> for more details.
+      <span class="hxAlert__status">FYI</span>
+      Reordering columns does not change tab order.<br />
+      Tab order is based on the DOM order, not visual appearance.
     </div>
   </div>
   <br />
-
   <p>
-    Explicit columns will take up a defined percentage of the row.
+    Use the <code>.hxOrder-{N}</code> class (1 &le; N &le; 12) to reorder
+    your columns.
   </p>
-
-  <p>
-    Use the <code>.hxCol-N</code> class (1 &le; N &le; 12)
-    to create columns that are a fraction of the row width.
-  </p>
-
   <ul>
     <li>
-      <code>.hxCol-B-N</code> responsive classes are available
+      <code>.hxOrder-{N}-{size}</code> responsive classes are available
     </li>
     <li>
-      <code>.hxCol-N</code> is shorthand for <code>.hxCol-xs-N</code>
+      <code>.hxOrder-{N}</code> is shorthand for <code>.hxOrder-{N}-xs</code>
     </li>
   </ul>
-
-  <div class="demo grid-demo">
-    <div class="demo-container text-center">
-      <div class="hxRow">
-        <div class="hxCol-12">12</div>
-      </div>
-      <div class="hxRow">
-        <div class="hxCol-1">1</div>
-        <div class="hxCol-11">11</div>
-      </div>
-      <div class="hxRow">
-        <div class="hxCol-2">2</div>
-        <div class="hxCol-10">10</div>
-      </div>
-      <div class="hxRow">
-        <div class="hxCol-3">3</div>
-        <div class="hxCol-9">9</div>
-      </div>
-      <div class="hxRow">
-        <div class="hxCol-4">4</div>
-        <div class="hxCol-8">8</div>
-      </div>
-      <div class="hxRow">
-        <div class="hxCol-5">5</div>
-        <div class="hxCol-7">7</div>
-      </div>
-      <div class="hxRow">
-        <div class="hxCol-6">6</div>
-        <div class="hxCol-6">6</div>
-      </div>
-    </div>
-  </div>
-
-  {% code 'html' %}
-    <div class="hxRow">
-      <div class="hxCol-12">12</div>
-    </div>
-    <div class="hxRow">
-      <div class="hxCol-1">1</div>
-      <div class="hxCol-11">11</div>
-    </div>
-    <div class="hxRow">
-      <div class="hxCol-2">2</div>
-      <div class="hxCol-10">10</div>
-    </div>
-    <div class="hxRow">
-      <div class="hxCol-3">3</div>
-      <div class="hxCol-9">9</div>
-    </div>
-    <div class="hxRow">
-      <div class="hxCol-4">4</div>
-      <div class="hxCol-8">8</div>
-    </div>
-    <div class="hxRow">
-      <div class="hxCol-5">5</div>
-      <div class="hxCol-7">7</div>
-    </div>
-    <div class="hxRow">
-      <div class="hxCol-6">6</div>
-      <div class="hxCol-6">6</div>
-    </div>
-  {% endcode %}
-</section>
-
-<section>
-  <h3 class="hxSubSectionTitle" id="nesting">Nesting Elements</h3>
-  <div class="hxAlert hxAlert--warning">
-    <div class="hxAlert__icon">
-      <hx-icon type="exclamation-triangle"></hx-icon>
-    </div>
-    <div class="hxAlert__text">
-      <span class="hxAlert__status">Warning</span>
-      Do not apply row and column classes to the same element.<br />
-      Rows and columns must be nested within one another.
-    </div>
-  </div>
-  <br />
-
-  <p>
-    You can nest rows and columns as deep as necessary. Gutters will align automatically.
-  </p>
-
-  <div class="demo grid-demo">
-    <div class="demo-container text-center">
-      <div class="hxRow">
-        <div class="hxCol-2">2</div>
-        <div class="hxCol-8">8
-          <div class="hxRow">
-            <div class="hxCol-6">6
-              <div class="hxRow">
-                <div class="hxCol-4">4</div>
-                <div class="hxCol-4">4</div>
-                <div class="hxCol-4">4</div>
-              </div>
-            </div>
-            <div class="hxCol-6">6
-              <div class="hxRow">
-                <div class="hxCol-6">6</div>
-                <div class="hxCol-6">6</div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div class="hxCol-2">2</div>
-      </div>
-    </div>
-  </div>
-  {% code 'html' %}
-    <div class="hxRow">
-      <div class="hxCol-2">2</div>
-      <div class="hxCol-8">8
-        <div class="hxRow">
-          <div class="hxCol-6">6
-            <div class="hxRow">
-              <div class="hxCol-4">4</div>
-              <div class="hxCol-4">4</div>
-              <div class="hxCol-4">4</div>
-            </div>
-          </div>
-          <div class="hxCol-6">6
-            <div class="hxRow">
-              <div class="hxCol-6">6</div>
-              <div class="hxCol-6">6</div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div class="hxCol-2">2</div>
-    </div>
-  {% endcode %}
-</section>
-
-<section>
-  <h3 class="hxSubSectionTitle" id="offsetting">Offsetting Columns</h3>
-  <p>
-    You can use the <code>.hxOffset-N</code> class (1 &le; N &le; 11)
-    to offset your column from the start of the row.
-  </p>
-
-  <ul>
-    <li>
-      <code>.hxOffset-B-N</code> responsive classes are available
-    </li>
-    <li>
-      <code>.hxOffset-N</code> is shorthand for <code>.hxOffset-xs-N</code>
-    </li>
-  </ul>
-
-  <div class="demo grid-demo">
-    <div class="demo-container text-center">
-      <div class="hxRow">
-        <div class="hxCol-2">2</div>
-        <div class="hxCol-6 hxOffset-1">6</div>
-        <div class="hxCol-2 hxOffset-1">2</div>
-      </div>
-      <div class="hxRow">
-        <div class="hxCol-1">1</div>
-        <div class="hxCol-8 hxOffset-1">8</div>
-        <div class="hxCol-1 hxOffset-1">1</div>
-      </div>
-      <div class="hxRow">
-        <div class="hxCol-2 hxOffset-1">2</div>
-        <div class="hxCol-4 hxOffset-1">4</div>
-        <div class="hxCol-2 hxOffset-1">2</div>
-      </div>
-      <div class="hxRow">
-        <div class="hxCol-4">4</div>
-        <div class="hxCol-4 hxOffset-4">4</div>
-      </div>
-      <div class="hxRow">
-        <div class="hxCol-3 hxOffset-1">3</div>
-        <div class="hxCol-2 hxOffset-1">2</div>
-        <div class="hxCol-3 hxOffset-1">3</div>
-      </div>
-      <div class="hxRow">
-        <div class="hxCol-5 hxOffset-1">5</div>
-        <div class="hxCol-5">5</div>
-      </div>
-    </div>
-  </div>
-
-  {% code 'html' %}
-    <div class="hxRow">
-      <div class="hxCol-1 hxOffset-1">1</div>
-      <div class="hxCol-6 hxOffset-1">6</div>
-      <div class="hxCol-1 hxOffset-1">1</div>
-    </div>
-    <div class="hxRow">
-      <div class="hxCol-1">1</div>
-      <div class="hxCol-8 hxOffset-1">8</div>
-      <div class="hxCol-1 hxOffset-1">1</div>
-    </div>
-    <div class="hxRow">
-      <div class="hxCol-2 hxOffset-1">2</div>
-      <div class="hxCol-4 hxOffset-1">4</div>
-      <div class="hxCol-2 hxOffset-1">2</div>
-    </div>
-    <div class="hxRow">
-      <div class="hxCol-4">4</div>
-      <div class="hxCol-4 hxOffset-4">4</div>
-    </div>
-    <div class="hxRow">
-      <div class="hxCol-3 hxOffset-1">3</div>
-      <div class="hxCol-2 hxOffset-1">2</div>
-      <div class="hxCol-3 hxOffset-1">3</div>
-    </div>
-    <div class="hxRow">
-      <div class="hxCol-5 hxOffset-1">5</div>
-      <div class="hxCol-5">5</div>
-    </div>
-  {% endcode %}
-</section>
-
-<section>
-  <h3 class="hxSubSectionTitle" id="reordering">Reordering Columns</h3>
-  <p>
-    Use the <code>.hxOrder-N</code> classes (1 &le; N &le; 12) to
-    reorder your columns.
-  </p>
-
-  <ul>
-    <li>
-      <code>.hxOrder-B-N</code> responsive classes are available
-    </li>
-    <li>
-      <code>.hxOrder-N</code> is shorthand for <code>.hxOrder-xs-N</code>
-    </li>
-  </ul>
-
   <p>
     The columns below are coded in HTML in the order of 2-4-1-3.<br />
     The <code>.hxOrder-*</code> classes reordered them in the proper
     numerical order.
   </p>
-
   <div class="demo grid-demo">
     <div class="demo-container text-center">
       <div class="hxRow">
@@ -382,28 +282,20 @@ assets:
   {% endcode %}
 </section>
 
-<section>
-  <h3 class="hxSubSectionTitle" id="responsive">Responsive Layout</h3>
-  <div class="hxAlert">
-    <div class="hxAlert__icon">
-      <hx-icon type="info-circle"></hx-icon>
-    </div>
-    <div class="hxAlert__text">
-      <span class="hxAlert__status">NOTE</span>
-      Responsive column classes override <a href="#automatic">automatic columns</a>.
-    </div>
-  </div>
-  <br />
-
-  <p>
-    Each responsive class corresponds to the <em>minimum breakpoint</em>
-    required to achieve that layout.
-  </p>
-
-  <p>
-    If you mix responsive clases, larger breakpoints will trump smaller ones.
-  </p>
-
+<section><!-- responsive options -->
+  <h2 class="hxSectionTitle" id="responsive-options">Responsive Options</h2>
+  <ul>
+    <li>All column modifiers support adding an optional breakpoint.</li>
+    <li>
+      Omitting the breakpoint will default to <code>xs</code>
+      (applies to all breakpoints).
+    </li>
+    <li>
+      Each respoinsive class corresponds to the <em>minimum</em> breakpoint
+      required to achieve the desired appearance.
+    </li>
+    <li>Larger breakpoints override smaller ones.</li>
+  </ul>
   <table class="table table-condensed">
     <thead>
       <tr>
@@ -415,231 +307,285 @@ assets:
     </thead>
     <tbody>
       <tr>
-        <td><code>.<i>hxClass</i>-<b>xs</b>-N</code></td>
+        <td><code>.<i>hxModifier</i>-{N}[-<b>xs</b>]</code></td>
         <td><code>0em (0px)</code></td>
         <td>N/A</td>
         <td>all below</td>
       </tr>
       <tr>
-        <td><code>.<i>hxClass</i>-<b>sm</b>-N</code></td>
+        <td><code>.<i>hxModifier</i>-{N}-<b>sm</b></code></td>
         <td><code>40em (~640px)</code></td>
         <td>all above</td>
         <td>all below</td>
       </tr>
       <tr>
-        <td><code>.<i>hxClass</i>-<b>md</b>-N</code></td>
+        <td><code>.<i>hxModifier</i>-{N}-<b>md</b></code></td>
         <td><code>64em (~1024px)</code></td>
         <td>all above</td>
         <td>all below</td>
       </tr>
       <tr>
-        <td><code>.<i>hxClass</i>-<b>lg</b>-N</code></td>
+        <td><code>.<i>hxModifier</i>-{N}-<b>lg</b></code></td>
         <td><code>75em (~1200px)</code></td>
         <td>all above</td>
         <td>all below</td>
       </tr>
       <tr>
-        <td><code>.<i>hxClass</i>-<b>xl</b>-N</code></td>
+        <td><code>.<i>hxModifier</i>-{N}-<b>xl</b></code></td>
         <td><code>90em (~1440px)</code></td>
         <td>all above</td>
         <td>N/A</td>
       </tr>
     </tbody>
   </table>
-
   <div class="demo grid-demo">
     <div class="demo-container text-center">
       <div id="querySize"></div>
       <div class="hxRow">
-        <div class="demoCol hxCol-12 hxCol-sm-4 hxCol-md-3 hxCol-lg-2 hxCol-xl-1"></div>
-        <div class="demoCol hxCol-6 hxCol-sm-4 hxCol-md-6 hxCol-lg-8 hxCol-xl-10"></div>
-        <div class="demoCol hxCol-6 hxCol-sm-4 hxCol-md-3 hxCol-lg-2 hxCol-xl-1"></div>
+        <div class="demoCol hxCol hxSpan-12-xs hxSpan-4-sm hxSpan-3-md hxSpan-2-lg hxSpan-1-xl"></div>
+        <div class="demoCol hxCol hxSpan-6-xs hxSpan-4-sm hxSpan-6-md hxSpan-8-lg hxSpan-10-xl"></div>
+        <div class="demoCol hxCol hxSpan-6-xs hxSpan-4-sm hxSpan-3-md hxSpan-2-lg hxSpan-1-xl"></div>
       </div>
       <div class="hxRow">
-        <div class="demoCol hxCol-12 hxCol-sm-4 hxCol-md-3 hxCol-lg-2 hxCol-xl-1"></div>
-        <div class="demoCol hxCol-12 hxCol-sm-8 hxCol-md-9 hxCol-lg-10 hxCol-xl-11"></div>
+        <div class="demoCol hxCol hxSpan-12-xs hxSpan-4-sm hxSpan-3-md hxSpan-2-lg hxSpan-1-xl"></div>
+        <div class="demoCol hxCol hxSpan-12-xs hxSpan-8-sm hxSpan-9-md hxSpan-10-lg hxSpan-11-xl"></div>
       </div>
       <div class="hxRow">
-        <div class="demoCol hxCol-12 hxCol-sm-8 hxCol-md-6 hxCol-lg-4 hxCol-xl-3"></div>
-        <div class="demoCol hxCol-12 hxCol-sm-4 hxCol-md-6 hxCol-lg-8 hxCol-xl-9"></div>
-      </div>
-    </div>
-  </div>
-
-  {% code 'html' %}
-    <div class="hxRow">
-      <div class="hxCol-12 hxCol-sm-4 hxCol-md-3 hxCol-lg-2 hxCol-xl-1"></div>
-      <div class="hxCol-6 hxCol-sm-4 hxCol-md-6 hxCol-lg-8 hxCol-xl-10"></div>
-      <div class="hxCol-6 hxCol-sm-4 hxCol-md-3 hxCol-lg-2 hxCol-xl-1"></div>
-    </div>
-    <div class="hxRow">
-      <div class="hxCol-12 hxCol-sm-4 hxCol-md-3 hxCol-lg-2 hxCol-xl-1"></div>
-      <div class="hxCol-12 hxCol-sm-8 hxCol-md-9 hxCol-lg-10 hxCol-xl-11"></div>
-    </div>
-    <div class="hxRow">
-      <div class="hxCol-12 hxCol-sm-8 hxCol-md-6 hxCol-lg-4 hxCol-xl-3"></div>
-      <div class="hxCol-12 hxCol-sm-4 hxCol-md-6 hxCol-lg-8 hxCol-xl-9"></div>
-    </div>
-  {% endcode %}
-</section>
-
-<section>
-  <h3 class="hxSubSectionTitle" id="wrapping">Column Wrapping</h3>
-  <p>
-    The following example should arrange the content into 3 columns on small
-    screens, 4 columns on medium screens, and 6 columns on all other sizes.
-  </p>
-
-  <div class="demo grid-demo">
-    <div class="demo-container text-left drop-cap">
-      <div class="hxRow">
-        <div class="hxCol-sm-4 hxCol-md-3 hxCol-lg-2">
-          <p>
-            A The best way to rank cross-functional methodology is
-            to appropriately get their task.
-          </p>
-        </div>
-        <div class="hxCol-sm-4 hxCol-md-3 hxCol-lg-2">
-          <p>
-            B It was discovered that by nearly preventing the WIP
-            stories, we can work the acceptance VOC emergence around
-            the pirate velocity.
-          </p>
-        </div>
-        <div class="hxCol-sm-4 hxCol-md-3 hxCol-lg-2">
-          <p>
-            C Try to adapt the relative sprint planning meeting,
-            maybe it will help close the VOC sprints.
-          </p>
-        </div>
-        <div class="hxCol-sm-4 hxCol-md-3 hxCol-lg-2">
-          <p>
-            D Given standup specs, efficiently launching the visible
-            commitment until the domain kanban will eventually code
-            the alpha lifecycle management.
-          </p>
-        </div>
-        <div class="hxCol-sm-4 hxCol-md-3 hxCol-lg-2">
-          <p>
-            E As a user, I should be able to inspect the distributed
-            product vision so that I can detail the patch-level MVP
-            sprints outside the sustainable bugs.
-          </p>
-        </div>
-        <div class="hxCol-sm-4 hxCol-md-3 hxCol-lg-2">
-          <p>
-            F If we block except the story points, we can get the
-            extended planning game above the VOC collaboration.
-          </p>
-        </div>
-        <div class="hxCol-sm-4 hxCol-md-3 hxCol-lg-2">
-          <p>
-            G As a user, I should be able to burn out the pirate
-            collaboration so that I can code the standup VOC wikis
-            along the single customers.
-          </p>
-        </div>
+        <div class="demoCol hxCol hxSpan-12-xs hxSpan-8-sm hxSpan-6-md hxSpan-4-lg hxSpan-3-xl"></div>
+        <div class="demoCol hxCol hxSpan-12-xs hxSpan-4-sm hxSpan-6-md hxSpan-8-lg hxSpan-9-xl"></div>
       </div>
     </div>
   </div>
   {% code 'html' %}
     <div class="hxRow">
-      <div class="hxCol-sm-4 hxCol-md-3 hxCol-lg-2">...</div>
-      <div class="hxCol-sm-4 hxCol-md-3 hxCol-lg-2">...</div>
-      <div class="hxCol-sm-4 hxCol-md-3 hxCol-lg-2">...</div>
-      <div class="hxCol-sm-4 hxCol-md-3 hxCol-lg-2">...</div>
-      <div class="hxCol-sm-4 hxCol-md-3 hxCol-lg-2">...</div>
-      <div class="hxCol-sm-4 hxCol-md-3 hxCol-lg-2">...</div>
-      <div class="hxCol-sm-4 hxCol-md-3 hxCol-lg-2">...</div>
+      <div class="demoCol hxCol hxSpan-12-xs hxSpan-4-sm hxSpan-3-md hxSpan-2-lg hxSpan-1-xl"></div>
+      <div class="demoCol hxCol hxSpan-6-xs hxSpan-4-sm hxSpan-6-md hxSpan-8-lg hxSpan-10-xl"></div>
+      <div class="demoCol hxCol hxSpan-6-xs hxSpan-4-sm hxSpan-3-md hxSpan-2-lg hxSpan-1-xl"></div>
+    </div>
+    <div class="hxRow">
+      <div class="demoCol hxCol hxSpan-12-xs hxSpan-4-sm hxSpan-3-md hxSpan-2-lg hxSpan-1-xl"></div>
+      <div class="demoCol hxCol hxSpan-12-xs hxSpan-8-sm hxSpan-9-md hxSpan-10-lg hxSpan-11-xl"></div>
+    </div>
+    <div class="hxRow">
+      <div class="demoCol hxCol hxSpan-12-xs hxSpan-8-sm hxSpan-6-md hxSpan-4-lg hxSpan-3-xl"></div>
+      <div class="demoCol hxCol hxSpan-12-xs hxSpan-4-sm hxSpan-6-md hxSpan-8-lg hxSpan-9-xl"></div>
     </div>
   {% endcode %}
 </section>
 
-<section>
-  <h3 class="hxSubSectionTitle" id="styling">Styling the Grid</h3>
+<section><!-- column wrapping -->
+  <h2 class="hxSectionTitle" id="column-wrapping">Column Wrapping</h2>
   <div class="hxAlert">
     <div class="hxAlert__icon">
       <hx-icon type="info-circle"></hx-icon>
     </div>
     <div class="hxAlert__text">
       <span class="hxAlert__status">NOTE</span>
-      Avoid styling rows and columns.<br />
-      Add a container within a column to apply styling.
+      Columns wrap if the total column width count within the row exceeds 12.
     </div>
   </div>
   <br />
-
   <p>
-    Because styles for rows and columns are meticulously defined to support
-    the grid definition, any modification to the <code>margin</code>,
-    <code>padding</code>, or geometry of these elements will affect the
-    layout.
+    The following example should arrange the content into:
   </p>
-
   <ul>
-    <li>
-      Wrap your content in a <code>&lt;div&gt;</code> and style
-      using a custom CSS class.
-    </li>
+    <li>3 columns on small screens</li>
+    <li>4 columns on medium screens</li>
+    <li>6 columns on all other sizes</li>
   </ul>
+  <div class="demo grid-demo">
+    <div class="demo-container text-center">
+      <div class="hxRow">
+        <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Snow White</div>
+        <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">The Evil Queen</div>
+        <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">The Prince</div>
+        <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Happy</div>
+        <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Sleepy</div>
+        <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Sneezy</div>
+        <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Grumpy</div>
+        <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Bashful</div>
+        <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Dopey</div>
+        <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Doc</div>
+      </div>
+    </div>
+  </div>
+  {% code 'html' %}
+    <div class="hxRow">
+      <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Snow White</div>
+      <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">The Evil Queen</div>
+      <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">The Prince</div>
+      <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Happy</div>
+      <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Sleepy</div>
+      <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Sneezy</div>
+      <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Grumpy</div>
+      <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Bashful</div>
+      <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Dopey</div>
+      <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Doc</div>
+    </div>
+  {% endcode %}
+</section>
 
+<section><!-- nesting containers -->
+  <h2 class="hxSectionTitle" id="nesting-containers">Nesting Containers</h2>
+  <div class="hxAlert hxAlert--warning">
+    <div class="hxAlert__icon">
+      <hx-icon type="exclamation-triangle"></hx-icon>
+    </div>
+    <div class="hxAlert__text">
+      <span class="hxAlert__status">Warning</span>
+      Do not apply row and column container classes to the same element.
+    </div>
+  </div>
+  <br />
+  <p>You can nest rows and columns as deep as necessary.</p>
+  <div class="demo grid-demo">
+    <div class="demo-container text-center">
+      <div class="hxRow">
+        <div class="hxCol hxSpan-12">12
+          <div class="hxRow">
+            <div class="hxCol hxSpan-6">6
+              <div class="hxRow">
+                <div class="hxCol hxSpan-4">4</div>
+                <div class="hxCol hxSpan-4">4</div>
+                <div class="hxCol hxSpan-4">4</div>
+              </div>
+            </div>
+            <div class="hxCol hxSpan-6">6
+              <div class="hxRow">
+                <div class="hxCol hxSpan-3">3</div>
+                <div class="hxCol hxSpan-9">9</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  {% code 'html' %}
+    <div class="hxRow">
+      <div class="hxCol hxSpan-12">12
+        <div class="hxRow">
+          <div class="hxCol hxSpan-6">6
+            <div class="hxRow">
+              <div class="hxCol hxSpan-4">4</div>
+              <div class="hxCol hxSpan-4">4</div>
+              <div class="hxCol hxSpan-4">4</div>
+            </div>
+          </div>
+          <div class="hxCol hxSpan-6">6
+            <div class="hxRow">
+              <div class="hxCol hxSpan-3">3</div>
+              <div class="hxCol hxSpan-9">9</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  {% endcode %}
+</section>
+
+<section><!-- styling containers -->
+  <h2 class="hxSectionTitle" id="styling-containers">Styling Containers</h2>
+  <div class="hxAlert hxAlert--warning">
+    <div class="hxAlert__icon">
+      <hx-icon type="exclamation-triangle"></hx-icon>
+    </div>
+    <div class="hxAlert__text">
+      <span class="hxAlert__status">Warning</span>
+      Do not attempt to style rows or columns directly.
+    </div>
+  </div>
+  <br />
+  <ul>
+    <li>Rows have margins set to align the outer columns with surrounding content.</li>
+    <li>Columns in a row have padding applied to them to simulate gutters.</li>
+    <li>Wrap your content in a <code>&lt;div&gt;</code> to apply custom CSS.</li>
+  </ul>
   <div class="demo grid-demo">
     <div class="hxRow">
-      <div class="hxCol-4">
+      <div class="hxCol hxSpan-4">
         <p>
           As a user, I should be able to measure the flexible project
           management so that I can decide the alpha VOC relationships
           outside the big interactions. If we adjust upon the relationships,
-          we can get the pair meeting outside the WIP commitment. Opening
-          the trends should allow our software development to adjust the
-          vanity colocation behind the item. It was discovered that by never
-          satifying the PR deadlines, we can satify the pirate XP impediment
-          around the major standard.
+          we can get the pair meeting outside the WIP commitment.
         </p>
       </div>
-      <div class="hxCol-4">
-        <div class="styled-container">
+      <div class="hxCol hxSpan-4">
+        <div class="example-styled-container">
           <p>
-            This is a custom styled container! Notice how it fits inside the
-            green areas of the grid columns.
-          </p>
-          <p>
-            As a user, I should be able to measure the flexible project
-            management so that I can decide the alpha VOC relationships
-            outside the big interactions. If we adjust upon the relationships,
-            we can get the pair meeting outside the WIP commitment. Opening
-            the trends should allow our software development to adjust the
-            vanity colocation behind the item.
+            This is a custom styled container! Notice how it fills the
+            green areas of the column.
           </p>
         </div>
       </div>
-      <div class="hxCol-4">
+      <div class="hxCol hxSpan-4">
         <p>
           As a user, I should be able to measure the flexible project
           management so that I can decide the alpha VOC relationships
           outside the big interactions. If we adjust upon the relationships,
-          we can get the pair meeting outside the WIP commitment. Opening
-          the trends should allow our software development to adjust the
-          vanity colocation behind the item. It was discovered that by never
-          satifying the PR deadlines, we can satify the pirate XP impediment
-          around the major standard.
+          we can get the pair meeting outside the WIP commitment.
         </p>
       </div>
     </div>
   </div>
   {% code 'html' %}
     <div class="hxRow">
-      <div class="hxCol-4">
+      <div class="hxCol hxSpan-4">
         <p>...</p>
       </div>
-      <div class="hxCol-4">
-        <div class="styled-container">
-          <p>This is a custom styled container.</p>
+      <div class="hxCol hxSpan-4">
+        <div class="example-styled-container">
+          <p>
+            This is a custom styled container! Notice how it fills the
+            green areas of the column.
+          </p>
         </div>
       </div>
-      <div class="hxCol-4">
+      <div class="hxCol hxSpan-4">
         <p>...</p>
       </div>
+    </div>
+  {% endcode %}
+</section>
+
+<section><!-- going gutterless -->
+  <h2 class="hxSectionTitle" id="going-gutterless">Going Gutterless</h2>
+  <ul>
+    <li>
+      Add the <code>.hxGutterless</code> CSS class to your row container
+      to remove gutters from its immediate children.
+    </li>
+  </ul>
+  <p>
+    <small>
+      Notice how the nested row in the second column still applies its gutters.
+    </small>
+  </p>
+  <div class="demo grid-demo">
+    <div class="demo-container text-center">
+      <div class="hxRow hxGutterless">
+        <div class="hxCol">1/3</div>
+        <div class="hxCol">1/3
+          <div class="hxRow">
+            <div class="hxCol">1/2</div>
+            <div class="hxCol">1/2</div>
+          </div>
+        </div>
+        <div class="hxCol">1/3</div>
+      </div>
+    </div>
+  </div>
+  {% code 'html' %}
+    <div class="hxRow hxGutterless">
+      <div class="hxCol">1/3</div>
+      <div class="hxCol">1/3
+        <div class="hxRow">
+          <div class="hxCol">1/2</div>
+          <div class="hxCol">1/2</div>
+        </div>
+      </div>
+      <div class="hxCol">1/3</div>
     </div>
   {% endcode %}
 </section>

--- a/source/components/icon/index.html
+++ b/source/components/icon/index.html
@@ -84,7 +84,7 @@ assets:
   <p>There are {{ data.icons.length }} icons available!</p>
   <div class="hxRow">
     {% for icon in data.icons %}
-      <div class="hxCol-xs-12 hxCol-sm-6 hxCol-md-4 hxCol-xl-3">
+      <div class="hxCol hxSpan-12-xs hxSpan-6-sm hxSpan-4-md hxSpan-3-xl">
         <div class="demo icon-demo no-label">
           <hx-icon type="{{icon}}"></hx-icon>
           <p>

--- a/source/components/tabset/index.html
+++ b/source/components/tabset/index.html
@@ -19,7 +19,7 @@ assets:
     </div>
     <hx-tabpanel id="cupcake">
       <div class="hxRow">
-        <div class="hxCol-6">
+        <div class="hxCol hxSpan-6">
           <p>
             Cupcake ipsum dolor sit amet bonbon topping caramels. Sesame snaps
             gummi bears liquorice cookie chupa chups fruitcake croissant
@@ -27,7 +27,7 @@ assets:
             soufflé powder jelly.
           </p>
         </div>
-        <div class="hxCol-6">
+        <div class="hxCol hxSpan-6">
           <p>
             Sweet roll sesame snaps danish I love jelly wafer dragée soufflé
             cake. Cookie chocolate cake gingerbread powder icing. Ice cream
@@ -57,8 +57,8 @@ assets:
     </div>
     <hx-tabpanel id="cupcake">
       <div class="hxRow">
-        <div class="hxCol-6">...</div>
-        <div class="hxCol-6">...</div>
+        <div class="hxCol hxSpan-6">...</div>
+        <div class="hxCol hxSpan-6">...</div>
       </div>
     </hx-tabpanel>
     <hx-tabpanel id="biscuit">...</hx-tabpanel>


### PR DESCRIPTION
JIRA: https://jira.rax.io/browse/SURF-623

### LGTM's
- [x] Dev LGTM
- [x] Zoom LGTM

#### TL;DR

* `.hx{modifier}[-{size}]-{N}` renamed to `.hx{modifier}-{N}[-{size}]`
  * optional piece moved from _middle_ to _end_ of class name
* `.hxCol` split into `.hxCol` and `.hxSpan-{N}[-{size}]`
  * separates _content layout_ from _container sizing_
* `.hxCol` no longer applies a columnar flexbox layout. 
  * The majority of the time this is unneeded.
  * It changed some built-in browser behavior (margin collapsing; caused more space than necessary to be added to the document).
* added `.hxRow.hxGutterless` styling
* clarified documentation

#### BEFORE
* Container and width modifier classes were tightly coupled (can't use width modifiers without turning an element into a Column container).
* Documentation unclear when to use Row and Column containers.
* Modifier classes had their optional parts before the required parts
  * `.hxModifier[-{size}]-{N}`

![grid-before](https://user-images.githubusercontent.com/545605/33291795-af139f18-d38c-11e7-947b-c2f41f83a018.png)

#### AFTER
* Clearer documentation
* Modifier classes now have their optional parts at the end of the class name.
  * `.hxModifier-{N}[-{size}]`
* Gutterless rows now possible with `.hxRow.hxGutterless`

![grid-after](https://user-images.githubusercontent.com/545605/33345865-6c00c2e2-d453-11e7-9a93-516b100644cf.png)
