### PR TITLE
fix(getRootNode): correct root node element lookup

### DIFF
--- a/src/helix-ui/elements/HXDisclosureElement.js
+++ b/src/helix-ui/elements/HXDisclosureElement.js
@@ -78,7 +78,7 @@ export class HXDisclosureElement extends HXElement {
     get target () {
         if (!this._target) {
             let targetId = this.getAttribute('aria-controls');
-            this._target = document.getElementById(targetId);
+            this._target = this.getRootNode().getElementById(targetId);
         }
         return this._target;
     }

--- a/src/helix-ui/elements/HXMenuElement.js
+++ b/src/helix-ui/elements/HXMenuElement.js
@@ -58,9 +58,9 @@ export class HXMenuElement extends HXElement {
 
     get relativeElement () {
         if (this.relativeTo) {
-            return document.getElementById(this.relativeTo);
+            return this.getRootNode().getElementById(this.relativeTo);
         } else {
-            return document.querySelector(`[aria-controls="${this.id}"]`);
+            return this.getRootNode().querySelector(`[aria-controls="${this.id}"]`);
         }
     }
 

--- a/src/helix-ui/elements/HXPopoverElement.js
+++ b/src/helix-ui/elements/HXPopoverElement.js
@@ -41,7 +41,7 @@ export class HXPopoverElement extends HXElement {
             return;
         }
 
-        this._target = document.querySelector('[data-popover=' + this.id + ']');
+        this._target = this.getRootNode().querySelector('[data-popover=' + this.id + ']');
         if (!this._target) {
             return;
         }

--- a/src/helix-ui/elements/HXTooltipElement.js
+++ b/src/helix-ui/elements/HXTooltipElement.js
@@ -33,11 +33,11 @@ export class HXTooltipElement extends HXElement {
     connectedCallback () {
         this.$defaultAttribute('position', 'top');
         this.initialPosition = this.position;
-        this.$upgradeProperty('open');        
+        this.$upgradeProperty('open');
         this.$defaultAttribute('role', 'tooltip');
 
         if (this.id) {
-            this._target = document.querySelector('[data-tooltip=' + this.id + ']');
+            this._target = this.getRootNode().querySelector('[data-tooltip=' + this.id + ']');
         } else {
             return;
         }


### PR DESCRIPTION
* When elements are in LightDOM, `getRootNode()` will return the `document`.
* When the elements are composed inside a shadow root, `getRootNode()` will return the `shadowRoot`.

JIRA: n/a

### LGTM's
- [x] Dev LGTM
- [x] Zoom LGTM
