### PR TITLE
fix(Search): remove built-in X in IE and Edge

### DIFF
--- a/src/helix-ui/elements/_hx-element.less
+++ b/src/helix-ui/elements/_hx-element.less
@@ -6,3 +6,7 @@
   font: inherit;
   letter-spacing: inherit;
 }
+
+input[type="text"]::-ms-clear {
+  display: none;
+}


### PR DESCRIPTION
Removes the built-in "X" from text inputs in IE and Edge.

![screen shot 2018-03-14 at 7 28 26 pm](https://user-images.githubusercontent.com/545605/37439523-7b60228e-27c6-11e8-9dc2-ef39fd48c491.png)


### LGTM's
- [x] Dev LGTM (@nimbinatus)
