### PR TITLE
fix(Accordion): correct CSS in polyfilled browsers

### DIFF
--- a/src/helix-ui/styles/core/hx-accordion-panel.less
+++ b/src/helix-ui/styles/core/hx-accordion-panel.less
@@ -1,14 +1,17 @@
 hx-accordion-panel {
   display: block;
 
-  > :not([slot="header"]) {
+  // Hide content if closed (ignore header)
+  //
+  // Both :not() selectors have to be combined, because
+  // they cannot be selected in isolation.
+  // - :not([slot="header"]) is for modern browsers
+  // - :not(#toggle) is for polyfilled browsers
+  &:not([open]) > *:not([slot="header"]):not(#toggle) {
     display: none;
   }
 
-  &[open] > * {
-    display: block;
-  }
-
+  > #toggle.hx-accordion-panel, // polyfill rewrite
   > [slot="header"] {
     padding: 0.5rem 0;
   }


### PR DESCRIPTION
Closes #168

### LGTM's
- [x] Dev LGTM

### Screenshots
Screenshots are from Firefox 59 (polyfilled). I verified that the corrected styles still work on IE11 and Edge 16.

#### Before

_panels disappear when closed_
![mar-27-2018 15-31-33](https://user-images.githubusercontent.com/545605/37993387-272d59da-31d4-11e8-90d6-169225e4d589.gif)

#### After
_panels collapse when closed_
![mar-27-2018 15-34-19](https://user-images.githubusercontent.com/545605/37993453-58f3cfb2-31d4-11e8-9182-194082b6129f.gif)
