### PR TITLE
fix(Choice Tiles): correct focus bug

### DIFF
--- a/src/helix-ui/styles/modules/choice-tiles.less
+++ b/src/helix-ui/styles/modules/choice-tiles.less
@@ -1,4 +1,5 @@
 @import (reference) 'modules/grid';
+@import (reference) '_utils';
 
 .hxRow > label.hxChoice {
   #grid.column();
@@ -7,8 +8,21 @@
 // Layout & Geometry
 /* ========== COMMON ========== */
 label.hxChoice > input {
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  appearance: none;
+  border: 0;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
   position: absolute;
-  top: -200px;
+  width: 1px;
+  z-index: -10;
+
+  &:focus {
+    #Util.resetFocus();
+  }
 
   &:checked + hx-tile {
     hx-icon[type="checkmark"] {


### PR DESCRIPTION
* Prevent browsers from jumping to top of page when selecting a Choice Tile.

JIRA: https://jira.rax.io/browse/SURF-1011

### LGTM's
- [x] Dev LGTM
- [x] Zoom LGTM

### Screenshots
The browser should not scroll when I click a Choice Tile.

Browser | Before | After
----- | ----- | -----
Chrome | ![chrome-before-broke](https://user-images.githubusercontent.com/545605/38114707-046fafaa-336f-11e8-9fc2-13f313a9135d.gif) | ![chrome-after-works](https://user-images.githubusercontent.com/545605/38114720-0a87e8f8-336f-11e8-8a30-3ddcf949241b.gif)
Firefox ⭐️ | ![firefox-before-works](https://user-images.githubusercontent.com/545605/38114729-141b1d86-336f-11e8-9cae-07a5133f5aa1.gif) | ![firefox-after-works](https://user-images.githubusercontent.com/545605/38114731-194e74ce-336f-11e8-9e15-9dceb12c71a9.gif)
Safari ⭐️ | ![safari-before-works](https://user-images.githubusercontent.com/545605/38114757-307d24ec-336f-11e8-90d7-41c1a28f7ed5.gif) | ![safari-after-works](https://user-images.githubusercontent.com/545605/38114771-3db092fc-336f-11e8-8ccd-bfbc8b625f5d.gif)
Edge | ![edge-before-broke](https://user-images.githubusercontent.com/545605/38114777-439110e8-336f-11e8-8526-a01415ba08be.gif) | ![edge-after-works](https://user-images.githubusercontent.com/545605/38114785-490260ae-336f-11e8-9aa2-579c97c6a51d.gif)
IE11 | ![ie11-before-broke](https://user-images.githubusercontent.com/545605/38114790-4f2531c8-336f-11e8-867b-492753de2f08.gif) | ![ie11-after-works](https://user-images.githubusercontent.com/545605/38114789-4f16d150-336f-11e8-9776-9b05672d6a11.gif)

