### PR TITLE
fix(events): Emit non-bubbling events by default

### DIFF
--- a/docs/_templates/partials/after_footer.njk
+++ b/docs/_templates/partials/after_footer.njk
@@ -1,3 +1,4 @@
+<script src="dist/scripts/helix-ui.polyfills.js"></script>
 <script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>
 
 <!-- intelligently load ES5 Adapter (if needed) -->

--- a/docs/components/layouts/horizontal-layout-template.html
+++ b/docs/components/layouts/horizontal-layout-template.html
@@ -100,6 +100,9 @@
     {% include 'partials/footer_legal.njk' %}
   </footer>
 
+  <!-- FIXME: point to HelixUI polyfills in node_modules/helix-ui -->
+  <script src="dist/scripts/helix-ui.polyfills.min.js"></script>
+
   <!-- Browser polyfills (mainly for IE) -->
   <script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>
 

--- a/docs/components/layouts/vertical-layout-template.html
+++ b/docs/components/layouts/vertical-layout-template.html
@@ -97,6 +97,9 @@
     {% include 'partials/footer_legal.njk' %}
   </footer>
 
+  <!-- FIXME: point to HelixUI polyfills in node_modules/helix-ui -->
+  <script src="dist/scripts/helix-ui.polyfills.min.js"></script>
+
   <!-- Browser polyfills (mainly for IE) -->
   <script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -31,6 +31,7 @@ let lessPlugin = less({
     }
 });
 
+// Intro/Outro placed INSIDE the applied dependency function
 let intro = `window.addEventListener('WebComponentsReady', function () {`;
 let outro = `});`;
 
@@ -112,6 +113,37 @@ export default [
             commonjs(),
             htmlPlugin,
             lessPlugin,
+        ],
+    },
+
+    // src/polyfills.js --> dis/helix-ui.polyfills.js (IIFE)
+    {
+        input: 'src/polyfills.js',
+        sourcemap: false,
+        output: [
+            {
+                file: 'dist/scripts/helix-ui.polyfills.js',
+                format: 'iife',
+            }
+        ],
+        plugins: [
+            babelPlugin,
+        ],
+    },
+
+    // src/polyfills.js --> dis/helix-ui.polyfills.min.js (IIFE)
+    {
+        input: 'src/polyfills.js',
+        sourcemap: false,
+        output: [
+            {
+                file: 'dist/scripts/helix-ui.polyfills.min.js',
+                format: 'iife',
+            }
+        ],
+        plugins: [
+            babelPlugin,
+            uglify({}, minify),
         ],
     },
 ]

--- a/src/helix-ui/elements/HXElement.js
+++ b/src/helix-ui/elements/HXElement.js
@@ -86,12 +86,14 @@ export class HXElement extends HTMLElement {
         }
     }//$preventScroll()
 
-    $emit (evtName, details) {
-        let evt = new CustomEvent(evtName, {
+    $emit (evtName, opts) {
+        let options = Object.assign({}, {
             cancelable: true,
-            bubbles: true,
-            detail: details,
-        });
+            bubbles: false,
+        }, opts);
+
+        let evt = new CustomEvent(evtName, options);
+
         return this.dispatchEvent(evt);
     }//$emit
 
@@ -106,7 +108,7 @@ export class HXElement extends HTMLElement {
             bubbles: oldEvent.bubbles,
             cancelable: oldEvent.cancelable,
         });
-        this.dispatchEvent(newEvent);
+        return this.dispatchEvent(newEvent);
     }//$relayEvent()
 
     // TODO: may need a later update to add events based on element name/type

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -1,0 +1,2 @@
+// Entrypoint for browser polyfills
+import './polyfills/Object';

--- a/src/polyfills/Object.js
+++ b/src/polyfills/Object.js
@@ -1,0 +1,34 @@
+/* ========== Object ========== */
+
+/* ---------- assign() ---------- */
+// Affected Browsers: IE
+// Source: (MDN) https://goo.gl/UADxBn
+if (typeof Object.assign != 'function') {
+    // Must be writable: true, enumerable: false, configurable: true
+    Object.defineProperty(Object, "assign", {
+        value: function assign(target, varArgs) { // .length of function is 2
+            'use strict';
+            if (target == null) { // TypeError if undefined or null
+                throw new TypeError('Cannot convert undefined or null to object');
+            }
+
+            var to = Object(target);
+
+            for (var index = 1; index < arguments.length; index++) {
+                var nextSource = arguments[index];
+
+                if (nextSource != null) { // Skip over if undefined or null
+                    for (var nextKey in nextSource) {
+                        // Avoid bugs when hasOwnProperty is shadowed
+                        if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
+                            to[nextKey] = nextSource[nextKey];
+                        }
+                    }
+                }
+            }
+            return to;
+        },
+        writable: true,
+        configurable: true
+    });
+}//Object.assign()


### PR DESCRIPTION
* (HXElement) Update `$emit()`
  * Do NOT bubble events by default
  * Provide capability to override event configuration.
* (polyfills) Add `Object.assign()` polyfill.
* (Layouts) Update layout templates to include minified polyfill
* (docs) include polyfills in templates

### LGTM's
- [x] Dev LGTM
- [x] Zoom LGTM

### Screenshots

Before | After
----- | -----
![events-bubbling](https://user-images.githubusercontent.com/545605/38691675-25c0c65c-3e47-11e8-9709-40d6b437ce9d.gif) | ![events-non-bubbling](https://user-images.githubusercontent.com/545605/38691674-25ae8df2-3e47-11e8-8780-8cc5daa6f39b.gif)
