### PR TITLE
fix(CSS): correct placeholder color

### DIFF
--- a/src/helix-ui/styles/mixins.less
+++ b/src/helix-ui/styles/mixins.less
@@ -1,5 +1,5 @@
 .u-placeholder() {
-  color: @gray-700; // contrast @ 4.6:1
+  color: @gray-750;
   font-style: italic;
   font-weight: 400;
   opacity: 1;


### PR DESCRIPTION
Per discovery in slack discussion, the implemented color for placeholders doesn't match what was agreed upon in bowling on March 1 and March 13, 2018.

### LGTM's
- [x] Dev LGTM