### PR TITLE
Ship ES6 Modules

### DIFF
--- a/docs/_templates/partials/after_footer.njk
+++ b/docs/_templates/partials/after_footer.njk
@@ -7,14 +7,14 @@
 -->
 <script type="module" src="/dist/scripts/helix-ui.mjs"></script>
 
-<!-- LEGACY BROWSERS
+<!-- OTHER BROWSERS
   (IE11, Edge 15-, Firefox 59-, Chrome 60-, Safari 10.0-, Opera 46-)
 
-  Modern-ish browsers that don't support ES6 modules will load ES5
-  assets along with the ES5 adapter.
+  Browsers that don't support ES6 modules will load the ES5
+  adapter along with the ES5-compiled version of HelixUI.
 -->
 <script nomodule src="https://unpkg.com/@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js"></script>
-<script nomodule src="dist/scripts/helix-ui.browser.js"></script>
+<script defer nomodule src="dist/scripts/helix-ui.browser.js"></script>
 
 <!-- 3RD-PARTY LIBRARIES -->
 <script src="https://unpkg.com/vue@2.5.16/dist/vue.js"></script>

--- a/docs/_templates/partials/after_footer.njk
+++ b/docs/_templates/partials/after_footer.njk
@@ -1,14 +1,23 @@
-<!-- intelligently load ES5 Adapter (if needed) -->
-<span id="ce-es5-adapter">
-  <script>
-    if (!window.customElements) {
-      var elAdapter = document.querySelector('#ce-es5-adapter');
-      elAdapter.parentElement.removeChild(elAdapter);
-    }
-  </script>
-  <script src="https://unpkg.com/@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js"></script>
-</span>
+<!-- MODERN BROWSERS
+  (Edge 16+, Firefox 60+, Chrome 61+, Safari 10.1+, Opera 47+)
 
+  Browsers that support ES6 modules obviously support ES6 syntax,
+  so we don't need to transpile the module to ES5 and we don't need
+  to load the ES5 adapter, either.
+-->
+<script type="module" src="/dist/scripts/helix-ui.mjs"></script>
+
+<!-- LEGACY BROWSERS
+  (IE11, Edge 15-, Firefox 59-, Chrome 60-, Safari 10.0-, Opera 46-)
+
+  Modern-ish browsers that don't support ES6 modules will load ES5
+  assets along with the ES5 adapter.
+-->
+<script nomodule src="https://unpkg.com/@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js"></script>
+<script nomodule src="dist/scripts/helix-ui.browser.js"></script>
+
+<!-- 3RD-PARTY LIBRARIES -->
 <script src="https://unpkg.com/vue@2.5.16/dist/vue.js"></script>
-<script src="dist/scripts/helix-ui.browser.js"></script>
+
+<!-- DOCUMENTATION BEHAVIOR -->
 <script src="docs.js"></script>

--- a/docs/_templates/partials/head.njk
+++ b/docs/_templates/partials/head.njk
@@ -11,5 +11,4 @@
 
   <!-- Polyfill Loader -->
   <script src="https://unpkg.com/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
-
 </head>

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "v1"
   ],
   "main": "dist/scripts/helix-ui.js",
-  "module": "dist/scripts/helix-ui.es.js",
+  "module": "dist/scripts/helix-ui.mjs",
   "files": [
     "dist/"
   ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,123 +1,92 @@
 import babel from 'rollup-plugin-babel';
-import html from 'rollup-plugin-html';
-import json from 'rollup-plugin-json';
-import pkg from './package.json';
-import { uglify } from 'rollup-plugin-uglify';
-import { minify } from 'uglify-es';
-import less from './lib/rollup-plugin-less';
-import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
 import eslint from 'rollup-plugin-eslint';
+import html from 'rollup-plugin-html';
+import json from 'rollup-plugin-json';
+import less from './lib/rollup-plugin-less';
+import pkg from './package.json';
+import resolve from 'rollup-plugin-node-resolve';
+import { uglify } from 'rollup-plugin-uglify';
+import { minify } from 'uglify-es';
 
-let htmlPlugin = html ({
-    include: [
-        '**/*.svg',
-        '**/*.html',
-    ],
-    htmlMinifierOptions: {
-        collapseWhitespace: true,
-        quoteCharacter: "'", // reduces escape characters
-    },
-});
+let uglifyPlugin = uglify({}, minify);
 
-let babelPlugin = babel({
-    exclude: 'node_modules/**/*',
-});
-
-let lessPlugin = less({
-    options: {
-        paths: [
-            'src/helix-ui/styles',
-        ]
-    }
-});
-
-let eslintPlugin = eslint({
-    include: [
-        '**/*.js',
-    ],
-});
-
-// Intro/Outro placed INSIDE the applied dependency function
-let intro = `window.addEventListener('WebComponentsReady', function () {`;
-let outro = `});`;
-
-let browserOutput = {
-    format: 'umd',
-    intro,
-    outro,
-    sourcemap: false,
-}
+let basePlugins = [
+    json(),
+    resolve(),
+    commonjs(),
+    html({
+        include: [
+            '**/*.svg',
+            '**/*.html',
+        ],
+        htmlMinifierOptions: {
+            collapseWhitespace: true,
+            quoteCharacter: "'", // reduces escape characters
+        },
+    }),
+    less({
+        options: {
+            paths: [
+                'src/helix-ui/styles',
+            ]
+        }
+    }),
+];
 
 export default [
-    // src/browser-entry.js --> dist/helix-ui.browser.js (UMD)
+    // browser-entry.js --> helix-ui.browser.js (IIFE)
     {
         input: 'src/browser-entry.js',
-        output: [
-            {
-                ...browserOutput,
-                file: 'dist/scripts/helix-ui.browser.js',
-            }
-        ],
-        plugins: [
-            json(),
-            resolve(),
-            commonjs(),
-            htmlPlugin,
-            lessPlugin,
-            babelPlugin,
-        ],
-        watch: {
-            include: 'src/**/*',
-            exclude: 'node_modules/**',
+        output: {
+            file: 'dist/scripts/helix-ui.browser.js',
+            format: 'iife',
+            intro: `window.addEventListener('WebComponentsReady', function () {`,
+            outro: `});`,
         },
+        plugins: [
+            ...basePlugins,
+            eslint({ include: [ '**/*.js' ] }),
+            babel({ exclude: 'node_modules/**/*' }),
+        ],
     },
 
-    // src/browser-entry.js --> dis/helix-ui.browser.min.js (UMD)
+    // helix-ui.browser.js --> helix-ui.browser.min.js (IIFE)
     {
-        input: 'src/browser-entry.js',
-        output: [
-            {
-                ...browserOutput,
-                file: 'dist/scripts/helix-ui.browser.min.js',
-            }
-        ],
-        plugins: [
-            json(),
-            resolve(),
-            commonjs(),
-            htmlPlugin,
-            lessPlugin,
-            eslintPlugin,
-            babelPlugin,
-            uglify({}, minify),
-        ],
-        watch: {
-            include: 'src/**/*',
-            exclude: 'node_modules/**',
+        input: 'dist/scripts/helix-ui.browser.js',
+        output: {
+            file: 'dist/scripts/helix-ui.browser.min.js',
+            format: 'iife',
         },
+        plugins: [ uglifyPlugin ],
     },
 
-    // src/node-entry.js --> dist/helix-ui.js (CJS)
-    // src/node-entry.js --> dist/helix-ui.es.js (ESM)
+    // module-entry.js --> helix-ui.mjs (ESM)
+    {
+        input: 'src/module-entry.js',
+        output: {
+            file: pkg.module,
+            format: 'es',
+        },
+        plugins: [ ...basePlugins ],
+    },
+    // helix-ui.mjs --> helix-ui.min.mjs (ESM)
+    {
+        input: pkg.module,
+        output: {
+            file: 'dist/scripts/helix-ui.min.mjs',
+            format: 'es',
+        },
+        plugins: [ uglifyPlugin ],
+    },
+
+    // node-entry.js --> helix-ui.js (CJS)
     {
         input: 'src/node-entry.js',
-        output: [
-            {
-                file: pkg.main,
-                format: 'cjs',
-            },
-            {
-                file: pkg.module,
-                format: 'es',
-            }
-        ],
-        plugins: [
-            json(),
-            resolve(),
-            commonjs(),
-            htmlPlugin,
-            lessPlugin,
-        ],
+        output: {
+            file: pkg.main,
+            format: 'cjs',
+        },
+        plugins: [ ...basePlugins ],
     },
 ]

--- a/src/module-entry.js
+++ b/src/module-entry.js
@@ -1,2 +1,6 @@
 import HelixUI from './helix-ui/index';
+
+// Initialize on import
+HelixUI.initialize();
+
 export default HelixUI;


### PR DESCRIPTION
Update asset generation to ship ES6 modules for modern browser consumption.

## LGTM's
- [ ] Dev LGTM
- [ ] Zoom LGTM

## Benefits
* no need to transpile for modern browsers
  * little/no need for source maps
* eliminate `custom-element-es5-adapter.js` hack
* remove polyfill.io as a dependency
  * polyfills built in to legacy ES5 code
* efficiently load assets with modern vs legacy syntax

## Caveats
* JavaScript module loading adheres to CORS rules.
* Browsers perform strict mime checking before loading ES6 modules
  * Update your web server config to serve `.mjs` files as an approved [JavaScript MIME type](https://mimesniff.spec.whatwg.org/#javascript-mime-type).
  * NGINX via a [`types` stanza](https://nginx.org/en/docs/http/ngx_http_core_module.html#types)
  * Apache via [mod_mime `AddType` directive](https://httpd.apache.org/docs/2.4/mod/mod_mime.html#addtype)

_chrome load error due to invalid MIME type_
<img width="650" alt="screen shot 2018-05-15 at 9 12 13 pm" src="https://user-images.githubusercontent.com/545605/40092927-8a11cc5c-5885-11e8-9561-c3466726c58c.png">

## Compatibility
ES6 modules are supported by the latest versions of evergreen browsers (as of the release of Firefox 60). IE11 is the only browser we support that does not have ES6 module loading capabilities. Fortunately, javascript module loading has built-in support to fall back to ES5 syntax, for legacy browsers.

```html
<!-- load ES6 module first -->
<script type="module" src="/path/to/helix-ui.mjs"></script>
<!-- if the browser doesn't support modules, this acts as a fallback -->
<script nomodule src="/path/to/helix-ui.browser.js"></script>
```

### Screenshots
Here are some screenshots of various browsers and how they load javascript assets.

Browser | Dev Tools
----- | -----
Safari 11.0.3 | <img width="753" alt="safari11 0 3-network-javascript" src="https://user-images.githubusercontent.com/545605/40093029-ff4c4b50-5885-11e8-912f-cb6d828264b1.png">
Chrome 66 | <img width="565" alt="chrome66-network-javascript-and-console" src="https://user-images.githubusercontent.com/545605/40093031-ff5f9174-5885-11e8-90a5-0eb68b2b5182.png">
Opera 53 | <img width="526" alt="opera53-network-javascript-and-console" src="https://user-images.githubusercontent.com/545605/40093032-ff6fa10e-5885-11e8-8ff5-998ca5cd785a.png">
Edge 16 | <img width="626" alt="edge16-network" src="https://user-images.githubusercontent.com/545605/40093036-ff9f7f6e-5885-11e8-8301-9437511ce509.png">
Firefox 60 | <img width="608" alt="ff60-network-javascript-and-console" src="https://user-images.githubusercontent.com/545605/40093033-ff7edb60-5885-11e8-9177-491c190d7c3f.png">
Firefox 48 | <img width="640" alt="ff48-network-javascript-and-console" src="https://user-images.githubusercontent.com/545605/40093035-ff8fda78-5885-11e8-9f1d-7b48de081d6d.png">
IE 11 | <img width="530" alt="ie11-network" src="https://user-images.githubusercontent.com/545605/40093037-ffb63a7e-5885-11e8-9257-1bbb3039cc91.png">
