### PR TITLE
fix(CSS) Change flex values for IE11 support

### DIFF
--- a/src/helix-ui/styles/components/lists.less
+++ b/src/helix-ui/styles/components/lists.less
@@ -24,17 +24,18 @@ hx-dl.hxVertical {
     flex-direction: column;
   }
 
+  hx-dt,
+  hx-dd {
+    flex: 0 0 auto;
+    max-width: none;
+  }
+
   hx-dt {
-    #grid.span(12);
-    flex: 0 1 auto;
     font-weight: 700;
     text-align: left;
   }
 
   hx-dd {
-    #grid.span(12);
-    flex: 0 1 auto;
-    display: block;
     margin: 0;
   }
 }

--- a/src/helix-ui/styles/components/lists.less
+++ b/src/helix-ui/styles/components/lists.less
@@ -26,12 +26,14 @@ hx-dl.hxVertical {
 
   hx-dt {
     #grid.span(12);
+    flex: 0 1 auto;
     font-weight: 700;
     text-align: left;
   }
 
   hx-dd {
     #grid.span(12);
+    flex: 0 1 auto;
     display: block;
     margin: 0;
   }


### PR DESCRIPTION
JIRA: https://jira.rax.io/browse/SDP-993

### LGTM's
- [x] Dev LGTM
- [x] Zoom LGTM

### Issue:
According to this [Stack Overflow post](https://stackoverflow.com/questions/21600345/flexbox-and-internet-explorer-11-displayflex-in-html), IE11 interprets default flex values a bit differently than other browsers. You can duplicate the problem by navigating to the `List` component demo in IE11 and checkoff `Vertical` view. You will see the text overlapped. By adding these lines of code, this correctly sets the flex values for IE11, and does not adversely affect Chrome or Firefox.

### Before:
![Before](https://user-images.githubusercontent.com/28536523/40329174-52c7f32e-5d0e-11e8-8b19-f755e7714a22.png)

### After:
![After](https://user-images.githubusercontent.com/28536523/40329223-7c6ed8b4-5d0e-11e8-834c-73b0c1543a84.png)

