### PR TITLE
docs(Grid): fix responsive options table

### DIFF
--- a/docs/components/grid/index.html
+++ b/docs/components/grid/index.html
@@ -298,7 +298,7 @@ also:
     </li>
     <li>Larger breakpoints override smaller ones.</li>
   </ul>
-  <table class="table table-condensed">
+  <table class="hxTable hxTable--condensed">
     <thead>
       <tr>
         <th>CSS Class</th>


### PR DESCRIPTION
Fix broken styles of "Responsive Options" table in Grid component documentation

### LGTM's
- [x] Dev/Design/Zoom LGTM

before | after
----- | -----
<img width="704" alt="screen shot 2018-06-08 at 1 41 45 am" src="https://user-images.githubusercontent.com/545605/41143016-71bc845e-6abd-11e8-99ec-a279b5ce17a4.png"> | <img width="699" alt="screen shot 2018-06-08 at 1 41 59 am" src="https://user-images.githubusercontent.com/545605/41143026-77249e54-6abd-11e8-8662-19adc90ba6a1.png">

