### PR TITLE
chore(npm): make @webcomponentsjs/webcomponents a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "files": [
     "dist/"
   ],
-  "dependencies": {
-    "@webcomponents/webcomponentsjs": "^2.0.0"
+  "peerDependencies": {
+    "@webcomponents/webcomponentsjs": "*"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -170,10 +170,6 @@
     "@webassemblyjs/wast-parser" "1.5.10"
     long "^3.2.0"
 
-"@webcomponents/webcomponentsjs@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.0.0.tgz#166e7489b9ce66f5c082a3360120cb27505f762f"
-
 a-sync-waterfall@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/a-sync-waterfall/-/a-sync-waterfall-1.0.0.tgz#38e8319d79379e24628845b53b96722b29e0e47c"


### PR DESCRIPTION
Per Slack discussion. We're making `@webcomponentsjs/webcomponents` a peer dependency to remove the hard requirement from the toolkit.

### LGTM's
- [x] Dev LGTM
- [x] Dev LGTM
- [x] Zoom LGTM
