### PR TITLE
chore(pipeline): fix build warning

### DIFF
--- a/lib/copy.js
+++ b/lib/copy.js
@@ -22,7 +22,6 @@ async function copyDocs () {
     // Directories to copy from docs/ to public/
     let dirs = [
         'images',
-        'vendor',
     ];
 
     await ensureDir(`${CONFIG.publicDir}`);


### PR DESCRIPTION
remove `vendor` from copied directories (no longer present)