### PR TITLE
fix(CSS): correct caption resets

### DIFF
--- a/docs/components/layouts/index.html
+++ b/docs/components/layouts/index.html
@@ -64,7 +64,7 @@ also:
         (<code>&lt;body class="hxVertical"&gt;</code>).
       </li>
     </ul>
-    <figure>
+    <figure class="hxFigure">
       {% code 'html' %}
         <!DOCTYPE html>
         <html lang="en">
@@ -99,7 +99,7 @@ also:
         (<code>&lt;body class="hxHorizontal"&gt;</code>).
       </li>
     </ul>
-    <figure>
+    <figure class="hxFigure">
       {% code 'html' %}
         <!DOCTYPE html>
         <html lang="en">
@@ -140,7 +140,7 @@ also:
         <li>Main content</li>
         <li>An optional siderail</li>
       </ol>
-      <figure>
+      <figure class="hxFigure">
         {% code 'html' %}
           <div id="stage">
             <!-- (optional) Product Navigation -->

--- a/docs/components/typography/index.html
+++ b/docs/components/typography/index.html
@@ -41,7 +41,19 @@ also:
         <h4>Heading Four</h4>
         <h5>Heading Five</h5>
       </div>
+      <footer>
+        {% code 'html' %}
+          <h1>Heading One</h1>
+          <h2>Heading Two</h2>
+          <h3>Heading Three</h3>
+          <h4>Heading Four</h4>
+          <h5>Heading Five</h5>
+        {% endcode %}
+      </footer>
     </div>
+
+    <br />
+
     <p>
       CSS class overrides are available if semantic elements
       don't match up with expected visual style.
@@ -92,15 +104,18 @@ also:
     </p>
     <div class="example">
       <div>
-        <div class="hxSubdued">Subdued DIV</div>
-        <p class="hxSubdued">Subdued P</p>
-        <span class="hxSubdued">Subdued SPAN</span>
+        <div class="hxSubdued">div.hxSubdued</div>
+        <p class="hxSubdued">p.hxSubdued</p>
+        <span class="hxSubdued">span.hxSubdued</span>
       </div>
+
       <footer>
         {% code 'html' %}
-          <div class="hxSubdued">Subdued DIV</div>
-          <p class="hxSubdued">Subdued P</div>
-          <span class="hxSubdued">Subdued SPAN</span>
+          <div class="hxSubdued">div.hxSubdued</div>
+
+          <p class="hxSubdued">p.hxSubdued</p>
+
+          <span class="hxSubdued">span.hxSubdued</span>
         {% endcode %}
       </footer>
     </div>
@@ -109,26 +124,43 @@ also:
   <section><!-- Caption -->
     <h2 id="caption">Caption</h2>
     <p>
-      Use the <code>&lt;caption&gt;</code> element, <code>&lt;figcaption&gt;</code>
-      element or add the <code>.hxCaption</code> CSS class to flow content to apply
-      the "caption" style.
+      Apply the Helix "caption" style with any of the following configurations:
     </p>
+    <ul>
+      <li>
+        A <code>&lt;caption&gt;</code> element within a
+        <a href="components/tables">Table</a>
+      </li>
+      <li>
+        A <code>&lt;figcaption&gt;</code> element within a
+        <code>&lt;figure class="hxFigure"&gt;</code>
+      </li>
+      <li>
+        Add the <code>.hxCaption</code> CSS class to any element
+      </li>
+    </ul>
     <div class="example">
       <div>
-        <p class="hxCaption">Caption</p>
+        <figure class="hxFigure">
+          <figcaption>figure.hxFigure figcaption</figcaption>
+        </figure>
+        <table class="hxTable">
+          <caption>table.hxTable caption</caption>
+        </table>
+        <p class="hxCaption">p.hxCaption</p>
       </div>
 
       <footer>
         {% code 'html' %}
-          <figure>
-            <figcaption>Caption</figcaption>
+          <figure class="hxFigure">
+            <figcaption>figure.hxFigure figcaption</figcaption>
           </figure>
-          <!-- or -->
-          <table>
-            <caption>Caption</caption>
+
+          <table class="hxTable">
+            <caption>table.hxTable caption</caption>
           </table>
-          <!-- or -->
-          <p class="hxCaption">Caption</p>
+
+          <p class="hxCaption">p.hxCaption</p>
         {% endcode %}
       </footer>
     </div>
@@ -137,20 +169,23 @@ also:
   <section><!-- Sub-Body -->
     <h2 id="sub-body">Sub-Body</h2>
     <p>
-      Use the <code>&lt;small&gt;</code> element or add the
-      <code>.hxSubBody</code> CSS class to flow content to apply the
-      "sub-body" style.
+      Apply the "sub-body" style with any of the following:
     </p>
+    <ul>
+      <li>A <code>&lt;small&gt;</code> element</li>
+      <li>Add the <code>.hxSubBody</code> CSS class to any element</li>
+    </ul>
     <div class="example">
       <div>
-        <p class="hxSubBody">Sub-Body</p>
+        <small>small</small>
+        <p class="hxSubBody">p.hxSubBody</p>
       </div>
 
       <footer>
         {% code 'html' %}
-          <small>Sub-Body</small>
-          <!-- or -->
-          <p class="hxSubBody">Sub-Body</p>
+          <small>small</small>
+
+          <p class="hxSubBody">p.hxSubBody</p>
         {% endcode %}
       </footer>
     </div>
@@ -262,9 +297,7 @@ also:
 
       <footer>
         {% code 'html' %}
-          <hx-error>
-            Error message goes here
-          </hx-error>
+          <hx-error>Error message goes here</hx-error>
         {% endcode %}
       </footer>
     </div>
@@ -294,7 +327,7 @@ also:
 
       <hx-tabcontent>
         <hx-tabpanel>
-          <figure>
+          <figure class="hxFigure">
             {% code 'html' %}
               <script type="text/javascript" src="path/to/script.js"></script>
               <link rel="stylesheet" href="path/to/style.css" />
@@ -324,7 +357,7 @@ also:
         </hx-tabpanel>
 
         <hx-tabpanel>
-          <figure>
+          <figure class="hxFigure">
             {% code 'javascript' %}
               /**
                * @description Multi-line comment
@@ -356,7 +389,7 @@ also:
         </hx-tabpanel>
 
         <hx-tabpanel>
-          <figure>
+          <figure class="hxFigure">
             {% code 'css' %}
               /* CSS Comment */
               @import url('https://fonts.googleapis.com/css?family=Roboto+Mono:100,100i,300,300i,400,400i,700,700i');
@@ -389,7 +422,7 @@ also:
         </hx-tabpanel>
 
         <hx-tabpanel>
-          <figure>
+          <figure class="hxFigure">
             {% code 'diff' %}
               Index: languages/ini.js
               ===================================================================
@@ -427,7 +460,7 @@ also:
         </hx-tabpanel>
 
         <hx-tabpanel>
-          <figure>
+          <figure class="hxFigure">
             {% code 'bash' %}
               #!/bin/bash
 
@@ -450,7 +483,7 @@ also:
         </hx-tabpanel>
 
         <hx-tabpanel>
-          <figure>
+          <figure class="hxFigure">
             {% code 'ini' %}
               ; boilerplate
               [package]
@@ -470,7 +503,7 @@ also:
         </hx-tabpanel>
 
         <hx-tabpanel>
-          <figure>
+          <figure class="hxFigure">
             {% code 'markdown' %}
               # hello world
 

--- a/docs/guides/getting-started/index.html
+++ b/docs/guides/getting-started/index.html
@@ -24,7 +24,7 @@ title: Getting Started with HelixUI
           <p>
             Using <a href="https://npmjs.com">npm</a>:
           </p>
-          <figure>
+          <figure class="hxFigure">
             {% code "bash" %}
               npm install helix-ui
             {% endcode %}
@@ -33,7 +33,7 @@ title: Getting Started with HelixUI
           <p>
             If you prefer <a href="https://yarnpkg.com/">Yarn</a>, use the following command:
           </p>
-          <figure>
+          <figure class="hxFigure">
             {% code "bash" %}
               yarn add helix-ui
             {% endcode %}

--- a/src/helix-ui/styles/base/typography.less
+++ b/src/helix-ui/styles/base/typography.less
@@ -23,13 +23,6 @@ h1, h2, h3, h4, h5, h6 {
   }
 }
 
-caption,
-figcaption {
-  font-size: 0.875rem;
-  font-weight: 300;
-  line-height: 1.5; // TODO: check if this is inherited?
-}
-
 // TODO: verify font size
 fieldset label {
   font-size: 0.875rem; // NOTE: Edge/IE will truncate to 0.88rem

--- a/src/helix-ui/styles/components/tables.less
+++ b/src/helix-ui/styles/components/tables.less
@@ -1,3 +1,5 @@
+@import (reference) "components/typography";
+
 // ===== States =====
 @state-selected-bg: @cyan-50;
 
@@ -20,6 +22,10 @@
 
 .hxTable {
   margin: 1.5rem 0;
+
+  caption {
+    &:extend(.hxCaption);
+  }
 
   thead {
     border-color: transparent;

--- a/src/helix-ui/styles/components/typography.less
+++ b/src/helix-ui/styles/components/typography.less
@@ -51,8 +51,12 @@ h6 {
   color: @gray-750;
 }
 
+
+.hxFigure figcaption,
 .hxCaption {
   color: @gray-800;
+  font-size: 0.875rem;
+  font-weight: 300;
 }
 
 .hxSubBody {

--- a/src/helix-ui/styles/overrides.less
+++ b/src/helix-ui/styles/overrides.less
@@ -3,7 +3,7 @@
     - Allow !important
 \* =============================== */
 
-figure {
+.hxFigure {
   // TODO: update this once spacing system is defined
   margin: 0;
 }


### PR DESCRIPTION
* `caption` -> `.hxTable caption`
* `figcaption` -> `.hxFigure figcaption` (may still need tweaking in future)
* `.hxCaption` updated to adhere to current specs
* Better Typography docs for Headings, Caption, Sub-Body, and Subdued

JIRA: n/a

Preview: https://deploy-preview-292--helix-ui.netlify.com/

### LGTM's
- [x] Dev LGTM
- [x] Zoom LGTM


### Screenshots

Demo | BEFORE | AFTER
----- | ----- | -----
Headings | <img width="745" alt="headings-before" src="https://user-images.githubusercontent.com/545605/43172400-bc92a928-8f74-11e8-8703-c0ecadbb5395.png"> | <img width="746" alt="headings-after" src="https://user-images.githubusercontent.com/545605/43172399-bc7de970-8f74-11e8-9693-bb407cb566b2.png">
Subdued | <img width="750" alt="subdued-before" src="https://user-images.githubusercontent.com/545605/43172409-c90ea4ae-8f74-11e8-9cf8-03ec9ecd79f9.png"> | <img width="748" alt="subdued-after" src="https://user-images.githubusercontent.com/545605/43172408-c8fd9f24-8f74-11e8-91e5-a2a696de9943.png">
Caption | <img width="748" alt="caption-before" src="https://user-images.githubusercontent.com/545605/43172420-d3c7eebe-8f74-11e8-8c2d-c586b3e175e2.png"> | <img width="749" alt="caption-after" src="https://user-images.githubusercontent.com/545605/43172770-a6e50e70-8f76-11e8-90bc-753243ad483d.png">
Sub-Body | <img width="745" alt="sub-body-before" src="https://user-images.githubusercontent.com/545605/43172429-df3dca98-8f74-11e8-9caa-c3da7f0aeb04.png"> | <img width="744" alt="sub-body-after" src="https://user-images.githubusercontent.com/545605/43172428-df2a73f8-8f74-11e8-81cf-acf73690e7d2.png">
Error Message | <img width="745" alt="errormessage-before" src="https://user-images.githubusercontent.com/545605/43172440-eaeb5dba-8f74-11e8-93fc-332bcb64c8c5.png"> | <img width="747" alt="errormessage-after" src="https://user-images.githubusercontent.com/545605/43172439-ead8d8d4-8f74-11e8-8311-13a3acd3cc6b.png">