### PR TITLE
fix(*): Fix Popover and Tooltip

### DIFF
--- a/docs/components/popovers/test.html
+++ b/docs/components/popovers/test.html
@@ -28,4 +28,18 @@ title: Testing - Popovers
       {% endfor %}
     </div>
   </section>
+
+  <section>
+    <h2>Unconventional HTML5-compatible ID</h2>
+    <p>
+      <button class="hxBtn" data-popover="2d90208e58f24216be64de517570c628" type="button">
+        <code>data-popover="2d90208e58f24216be64de517570c628"</code>
+      </button>
+    </p>
+    <hx-popover id="2d90208e58f24216be64de517570c628">
+      <hx-popover-body>
+        How do you like my hat?
+      </hx-popover-body>
+    </hx-popover>
+  </section>
 {% endblock %}

--- a/docs/components/tooltips/test.html
+++ b/docs/components/tooltips/test.html
@@ -26,4 +26,14 @@ title: Testing - Tooltips
       {% endfor %}
     </div>
   </section>
+
+  <section>
+    <h2>Unconventional HTML5-compatible ID</h2>
+    <p>
+      <span data-tooltip="2d90208e58f24216be64de517570c628">
+        <code>data-tooltip="2d90208e58f24216be64de517570c628"</code>
+      </span>
+      <hx-tooltip id="2d90208e58f24216be64de517570c628">Do you like my hat?</hx-tooltip>
+    </p>
+  </section>
 {% endblock %}

--- a/src/helix-ui/elements/HXPopoverElement.js
+++ b/src/helix-ui/elements/HXPopoverElement.js
@@ -54,7 +54,7 @@ export class HXPopoverElement extends HXElement {
             return;
         }
 
-        this._target = this.getRootNode().querySelector('[data-popover=' + this.id + ']');
+        this._target = this.getRootNode().querySelector(`[data-popover="${this.id}"]`);
         if (!this._target) {
             return;
         }
@@ -78,7 +78,7 @@ export class HXPopoverElement extends HXElement {
         return [ 'open' ];
     }
 
-    $onAttributeChange (attr, oldVal, newVal) { 
+    $onAttributeChange (attr, oldVal, newVal) {
         if (attr === 'open') {
             let isOpen = (newVal !== null);
             this.setAttribute('aria-hidden', !isOpen);

--- a/src/helix-ui/elements/HXTooltipElement.js
+++ b/src/helix-ui/elements/HXTooltipElement.js
@@ -55,7 +55,7 @@ export class HXTooltipElement extends HXElement {
         this.setAttribute('aria-hidden', !this.open);
 
         if (this.id) {
-            this._target = this.getRootNode().querySelector('[data-tooltip=' + this.id + ']');
+            this._target = this.getRootNode().querySelector(`[data-tooltip="${this.id}"]`);
         } else {
             return;
         }


### PR DESCRIPTION
* Correct logic to wrap attribute value with quotes, within querySelector() calls.

Closes #303 

### LGTM's
- [x] Dev LGTM
- [x] Zoom LGTM
