### PR TITLE
docs(*): annotate usage inline and add react compatibility ref 

### DIFF
--- a/docs/elements/hx-busy/index.html
+++ b/docs/elements/hx-busy/index.html
@@ -3,6 +3,7 @@ title: <hx-busy>
 minver: 0.4.0
 also:
   components/loaders: Loaders
+  guides/react-compatibility/#significant-white-space: Significant White Space (React Compatibility)
 ---
 {% extends 'element.njk' %}
 {% block content %}
@@ -13,6 +14,10 @@ also:
     </p>
 
     <dl class="hxBox-md metadata hxList">
+      <div>
+        <dt>Display</dt>
+        <dd>inline</dd>
+      </div>
       <div>
         <dt>Permitted Parents</dt>
         <dd>any</dd>

--- a/docs/elements/hx-checkbox/index.html
+++ b/docs/elements/hx-checkbox/index.html
@@ -3,6 +3,7 @@ title: <hx-checkbox>
 minver: 0.2.0
 also:
   components/checkboxes: Checkboxes
+  guides/react-compatibility/#significant-white-space: Significant White Space (React Compatibility)
 ---
 {% extends 'element.njk' %}
 {% block content %}
@@ -13,6 +14,10 @@ also:
     </p>
 
     <dl class="hxBox-md metadata hxList">
+      <div>
+        <dt>Display</dt>
+        <dd>inline</dd>
+      </div>
       <div>
         <dt>Permitted Parents</dt>
         <dd>any</dd>

--- a/docs/elements/hx-pill/index.html
+++ b/docs/elements/hx-pill/index.html
@@ -3,6 +3,7 @@ title: <hx-pill>
 minver: 0.8.0
 also:
   components/pills: Pills
+  guides/react-compatibility/#significant-white-space: Significant White Space (React Compatibility)
 ---
 {% extends 'element.njk' %}
 {% block content %}
@@ -11,8 +12,12 @@ also:
       The custom <code>{{page.title}}</code> element provides a pill-like
       element that can be optionally dismissed.
     </p>
-
+  
     <dl class="hxBox-md metadata hxList">
+      <div>
+        <dt>Display</dt>
+        <dd>inline</dd>
+      </div>
       <div>
         <dt>Permitted Parents</dt>
         <dd>any</dd>


### PR DESCRIPTION
* add documentation that `<hx-busy>` is an inline element
* add documentation that `<hx-pill>` is an inline element
* add documentation that `<hx-checkbox>` is an inline element
* add reference to significant white space section in react compatibility guide for above

Closes:
* SURF-1267 (JSX: Busy)
* SURF-1270 (JSX: Checkbox)
* SURF-1287 (JSX: Pills)

### LGTM's
- [x] Dev LGTM
- [x] Zoom LGTM
