### PR TITLE
chore(deps): update peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dist/"
   ],
   "peerDependencies": {
-    "@webcomponents/webcomponentsjs": "*"
+    "@webcomponents/webcomponentsjs": "^1.2.4 || ^2.0.4"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",


### PR DESCRIPTION
Relates to changes of the layout templates in #327 

Older versions of `@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js` ironically used ES6 syntax to convert ES5 constructor functions back into ES6 classes for use in modern browsers (i.e., any browser that _isn't_ Internet Explorer). This would throw an error if loaded in IE, so hacks had to be used to detect modern browsers in order to remove the adapter before it has a chance to load in IE (which didn't always work).

Version `1.2.4` and `2.0.4` (released 2018-08-01), fixes the adapter by simplifying its consumption.
Browser detection is baked-in (no need for `<span>` hack), which also eliminates errors being thrown in IE.

Instead of this:

```html
<span id="ce-es5-adapter">	
  <script>	
    if (!window.customElements) {	
      var elAdapter = document.querySelector('#ce-es5-adapter');	
      elAdapter.parentElement.removeChild(elAdapter);	
    }	
  </script>	
  <script src="path/to/custom-elements-es5-adapter.js"></script>	
</span>
```

Consumers can do this:

```html
<script src="path/to/custom-elements-es5-adapter.js"></script>
```

### LGTM's
- [x] Dev LGTM
- [x] Zoom LGTM
