### PR TITLE
Update Polyfills table to reflect Firefox 63 capabilities

### DIFF
--- a/docs/_data/polyfilled-apis.json5
+++ b/docs/_data/polyfilled-apis.json5
@@ -20,7 +20,7 @@
   {
     name: 'Element.attachShadow()',
     mdn: 'API/Element/attachShadow',
-    missing: ['firefox', 'edge', 'ie'],
+    missing: ['edge', 'ie'],
     polyfill: 'webcomponentsjs',
   },
   {
@@ -32,7 +32,7 @@
   {
     name: 'Element.shadowRoot',
     mdn: 'API/Element/shadowRoot',
-    missing: ['firefox', 'edge', 'ie'],
+    missing: ['edge', 'ie'],
     polyfill: 'webcomponentsjs',
   },
   {
@@ -68,7 +68,7 @@
   {
     name: 'Window.customElements',
     mdn: 'API/Window/customElements',
-    missing: ['firefox', 'edge', 'ie'],
+    missing: ['edge', 'ie'],
     polyfill: 'webcomponentsjs',
   },
 ]


### PR DESCRIPTION
Firefox 63 supports `Element.attachShadow()`, `Element.shadowRoot`, and `Window.customElements`

JIRA: 

### LGTM's
- [x] Dev LGTM
- [x] Zoom LGTM
