### PR TITLE
fix(CSS): correct :host selector specificity

### DIFF
--- a/src/helix-ui/elements/HXElement.less
+++ b/src/helix-ui/elements/HXElement.less
@@ -1,11 +1,9 @@
 @import (reference) "vars";
 
-:host {
-  *, *::before, *::after {
-    box-sizing: border-box;
-    // TODO: convert below properties into .inheritTypography() mixin
-    color: inherit;
-    font: inherit;
-    letter-spacing: inherit;
-  }
+*, *::before, *::after {
+  box-sizing: border-box;
+  // TODO: convert below properties into .inheritTypography() mixin
+  color: inherit;
+  font: inherit;
+  letter-spacing: inherit;
 }


### PR DESCRIPTION
* Corrects an issue with incorrect CSS specificity calculations of the `:host` selector in Blink-based browsers (Chrome/Opera)

JIRA: SURF-1465

### LGTM's
- [ ] Dev LGTM
- [ ] Zoom LGTM
