### PR TITLE
revert(polyfills): remove unnecessary isConnected polyfill

### DIFF
--- a/src/polyfills/Node.js
+++ b/src/polyfills/Node.js
@@ -1,9 +1,0 @@
-var proto = Node.prototype;
-if (!proto.hasOwnProperty('isConnected')) {
-    Object.defineProperty(proto, 'isConnected', {
-        enumerable: true,
-        get: function () {
-            return (this.getRootNode().nodeType === Node.DOCUMENT_NODE);
-        },
-    });
-}

--- a/src/polyfills/index.js
+++ b/src/polyfills/index.js
@@ -1,3 +1,2 @@
 import './ChildNode';
 import './Element';
-import './Node';


### PR DESCRIPTION
Removing, because `@webcomponents/shadydom` polyfill [already includes](https://github.com/webcomponents/shadydom/blob/master/src/patches/Node.js#L160-L184) the `Node.prototype.isConnected` polyfill.

JIRA: n/a

### LGTM's
- [x] Dev LGTM
- [x] Zoom LGTM
