### PR TITLE
docs(Buttons): clarify need for span around text node children

### DIFF
--- a/docs/components/buttons/index.html
+++ b/docs/components/buttons/index.html
@@ -3,6 +3,8 @@ title: Buttons
 minver: 0.1.6
 also:
   components/buttons/test.html: Testing - Buttons
+  components/loaders/#busy: Busy Loader
+  components/files/#file-selector: File Selector
   components/menus: Menus
   components/popovers: Popovers
   components/reveals: Reveals
@@ -61,23 +63,51 @@ also:
       </header>
 
       <div>
-        <button :class="classes" type="button">Button</button>
-        <a href="#" :class="classes">Link</a>
-        <input type="button" :class="classes" value="Input" @click.prevent />
-        <input type="submit" :class="classes" value="Submit" @click.prevent />
-        <input type="reset" :class="classes" value="Reset" @click.prevent />
+        <p>
+          <button :class="classes" type="button">
+            Press Me
+          </button>
+        </p>
+        <p>
+          <button :class="classes" disabled>
+            <span>Loading</span>
+            <hx-busy></hx-busy>
+          </button>
+        </p>
+        <p>
+          <a href="#" :class="classes">
+            <hx-icon type="download"></hx-icon>
+            <span>Download</span>
+          </a>
+        </p>
       </div>
 
       <footer>
         {% code 'html' %}{% raw %}
-          <button class="{{classes}}">Button</button>
-          <a href="#" class="{{classes}}">Link</a>
-          <input type="button" class="{{classes}}" value="Input" />
-          <input type="submit" class="{{classes}}" value="Submit" />
-          <input type="reset" class="{{classes}}" value="Reset" />{% endraw %}
+          <!-- text-only (no span necessary) -->
+          <button class="{{classes}}">
+            Press Me
+          </button>
+
+          <!-- text + non-text (span around text required) -->
+          <button class="{{classes}}" disabled>
+            <span>Loading</span>
+            <hx-busy></hx-busy>
+          </button>
+
+          <!-- non-text + text (span around text required) -->
+          <a href="#" class="{{classes}}">
+            <hx-icon type="download"></hx-icon>
+            <span>Download</span>
+          </a>{% endraw %}
         {% endcode %}
       </footer>
     </div>
+    <p class="hxSubBody hxSubdued">
+      <hx-icon type="info-circle"></hx-icon>
+      Text nodes within buttons <i>must</i> be wrapped in a <code>&lt;span&gt;</code>,
+      if non-text siblings are present.
+    </p>
   </section>
 
   <section>

--- a/docs/components/buttons/test.html
+++ b/docs/components/buttons/test.html
@@ -25,7 +25,7 @@ title: Testing - Buttons
 
   <!-- Button Element -->
   <section>
-    <h3>Button Element</h3>
+    <h2>Button Element</h2>
     <p>Using: <code>&lt;button&gt;</code></p>
     <table class="hxTable hxTable--condensed">
       {% for _variant in variants %}
@@ -47,7 +47,7 @@ title: Testing - Buttons
 
   <!-- Anchor Element -->
   <section>
-    <h3>Anchor Element</h3>
+    <h2>Anchor Element</h2>
     <p>Using: <code>&lt;a&gt;</code></p>
     <table class="hxTable hxTable--condensed">
       {% for _variant in variants %}
@@ -69,7 +69,7 @@ title: Testing - Buttons
 
   <!-- Link Element -->
   <section>
-    <h3>Link Element</h3>
+    <h2>Link Element</h2>
     <p>Using: <code>&lt;a href="#"&gt;</code></p>
     <table class="hxTable hxTable--condensed">
       {% for _variant in variants %}
@@ -112,4 +112,183 @@ title: Testing - Buttons
       </table>
     </section>
   {% endfor %}
+
+  <!-- Various Element Children -->
+  <section>
+    <h2>Various Element Children</h2>
+    <!-- konami icons -->
+    <p>
+      {% for _variant in variants %}
+        <button class="hxBtn {{_variant.style}}">
+          <hx-icon type="kbd-arrow-up"></hx-icon>
+          <hx-icon type="kbd-arrow-up"></hx-icon>
+          <hx-icon type="kbd-arrow-down"></hx-icon>
+          <hx-icon type="kbd-arrow-down"></hx-icon>
+          <hx-icon type="kbd-arrow-left"></hx-icon>
+          <hx-icon type="kbd-arrow-right"></hx-icon>
+          <hx-icon type="kbd-arrow-left"></hx-icon>
+          <hx-icon type="kbd-arrow-right"></hx-icon>
+        </button>
+      {% endfor %}
+    </p>
+    <!-- hx-icon + hx-icon -->
+    <p>
+      {% for _variant in variants %}
+        <button class="hxBtn {{_variant.style}}">
+          <hx-icon type="flag"></hx-icon>
+          <hx-icon type="angle-right"></hx-icon>
+        </button>
+      {% endfor %}
+    </p>
+    <!-- hx-busy + hx-icon -->
+    <p>
+      {% for _variant in variants %}
+        <button class="hxBtn {{_variant.style}}">
+          <hx-busy></hx-busy>
+          <hx-icon type="filter"></hx-icon>
+        </button>
+      {% endfor %}
+    </p>
+    <!-- hx-icon + hx-busy -->
+    <p>
+      {% for _variant in variants %}
+        <button class="hxBtn {{_variant.style}}">
+          <hx-icon type="phone"></hx-icon>
+          <hx-busy></hx-busy>
+        </button>
+      {% endfor %}
+    </p>
+    <!-- hx-icon + hx-busy + hx-icon -->
+    <p>
+      {% for _variant in variants %}
+        <button class="hxBtn {{_variant.style}}">
+          <hx-icon type="pencil"></hx-icon>
+          <hx-busy></hx-busy>
+          <hx-icon type="angle-right"></hx-icon>
+        </button>
+      {% endfor %}
+    </p>
+    <!-- hx-busy + hx-icon + hx-busy -->
+    <p>
+      {% for _variant in variants %}
+        <button class="hxBtn {{_variant.style}}">
+          <hx-busy></hx-busy>
+          <hx-icon type="calendar"></hx-icon>
+          <hx-busy></hx-busy>
+        </button>
+      {% endfor %}
+    </p>
+  </section>
+
+  <!-- Supported Markup (text + non-text children ) -->
+  <section>
+    <h2>Supported Markup</h2>
+    <p>
+      The following examples are supported and should have correct spacing.
+    </p>
+    <!-- hx-icon + text -->
+    <p>
+      {% for _variant in variants %}
+        <button class="hxBtn {{_variant.style}}">
+          <hx-icon type="angle-left"></hx-icon>
+          <span>prev</span>
+        </button>
+      {% endfor %}
+    </p>
+    <!-- text + hx-icon -->
+    <p>
+      {% for _variant in variants %}
+        <button class="hxBtn {{_variant.style}}">
+          <span>next</span>
+          <hx-icon type="angle-right"></hx-icon>
+        </button>
+      {% endfor %}
+    </p>
+    <!-- hx-icon + text + hx-icon -->
+    <p>
+      {% for _variant in variants %}
+        <button class="hxBtn {{_variant.style}}">
+          <hx-icon type="cog"></hx-icon>
+          <span>actions</span>
+          <hx-icon type="angle-down"></hx-icon>
+        </button>
+      {% endfor %}
+    </p>
+    <!-- text + hx-busy -->
+    <p>
+      {% for _variant in variants %}
+        <button class="hxBtn {{_variant.style}}" disabled>
+          <span>Loading</span>
+          <hx-busy></hx-busy>
+        </button>
+      {% endfor %}
+    </p>
+    <!-- hx-icon + text + hx-busy -->
+    <p>
+      {% for _variant in variants %}
+        <button class="hxBtn {{_variant.style}}">
+          <hx-icon type="cog"></hx-icon>
+          <span>wrapped text</span>
+          <hx-busy></hx-busy>
+        </button>
+      {% endfor %}
+    </p>
+  </section>
+
+  <hr />
+
+  <!-- Unsupported Markup (text + non-text children ) -->
+  <section>
+    <h2>Unsupported Markup</h2>
+    <p>
+      The following examples are not supported for button children spacing.
+    </p>
+    <!-- hx-icon + text -->
+    <p>
+      {% for _variant in variants %}
+        <button class="hxBtn {{_variant.style}}">
+          <hx-icon type="angle-left"></hx-icon>
+          prev
+        </button>
+      {% endfor %}
+    </p>
+    <!-- text + hx-icon -->
+    <p>
+      {% for _variant in variants %}
+        <button class="hxBtn {{_variant.style}}">
+          next
+          <hx-icon type="angle-right"></hx-icon>
+        </button>
+      {% endfor %}
+    </p>
+    <!-- hx-icon + text + hx-icon -->
+    <p>
+      {% for _variant in variants %}
+        <button class="hxBtn {{_variant.style}}">
+          <hx-icon type="cog"></hx-icon>
+          actions
+          <hx-icon type="angle-down"></hx-icon>
+        </button>
+      {% endfor %}
+    </p>
+    <!-- text + hx-busy -->
+    <p>
+      {% for _variant in variants %}
+        <button class="hxBtn {{_variant.style}}" disabled>
+          Loading
+          <hx-busy></hx-busy>
+        </button>
+      {% endfor %}
+    </p>
+    <!-- hx-icon + text + hx-busy -->
+    <p>
+      {% for _variant in variants %}
+        <button class="hxBtn {{_variant.style}}">
+          <hx-icon type="cog"></hx-icon>
+          unwrapped text
+          <hx-busy></hx-busy>
+        </button>
+      {% endfor %}
+    </p>
+  </section>
 {% endblock %}


### PR DESCRIPTION
Closes #426

### LGTM's
- [x] Dev LGTM
- [x] Zoom LGTM

### Screenshots

**Buttons Component (Before)**
<img width="817" alt="screen shot 2019-01-28 at 4 02 46 pm" src="https://user-images.githubusercontent.com/545605/51869584-a66e2600-2316-11e9-985d-2630f650c552.png">

**Buttons Component (After)**
<img width="819" alt="screen shot 2019-01-28 at 4 03 01 pm" src="https://user-images.githubusercontent.com/545605/51869573-99e9cd80-2316-11e9-9203-d66c55171b9c.png">

**Buttons Test (new)**
<img width="667" alt="screen shot 2019-01-28 at 4 03 18 pm" src="https://user-images.githubusercontent.com/545605/51869590-abcb7080-2316-11e9-802b-020f7d818edb.png">
