### PR TITLE
Update reset.less

### DIFF
--- a/src/helix-ui/styles/reset.less
+++ b/src/helix-ui/styles/reset.less
@@ -29,7 +29,7 @@ html {
 @import 'reset/html5';
 
 [hidden] {
-  display: none;
+  display: none !important;
 }
 
 small {


### PR DESCRIPTION
Any element with the `hidden` attribute should not be rendered. Therefore, the `[hidden]` attribute behaves more like a helper than a reset and needs `!important`.

Closes #440 

### LGTM's
- [x] Dev LGTM
- [x] Zoom LGTM
