### PR TITLE
docs(components): content and markup changes

### DIFF
--- a/docs/components/accordions/index.html
+++ b/docs/components/accordions/index.html
@@ -7,13 +7,21 @@ also:
   elements/hx-accordion-panel: <hx-accordion-panel>
 ---
 {% extends 'component.njk' %}
+
+{% block page_header %}
+  {# TODO: add component description #}
+{% endblock %}
+
 {% block content %}
   <section>
-    <h2 id="basic-accordion">Basic Accordion</h2>
-    <p>
-      A basic accordion will allow a user to expand and collapse
-      as many panels as desired.
-    </p>
+    <header>
+      <h2 id="basic-accordion">Basic Accordion</h2>
+      <p>
+        A basic accordion will allow a user to expand and collapse
+        as many panels as desired.
+      </p>
+    </header>
+
     <div class="example">
       <div>
         <hx-accordion>
@@ -70,12 +78,15 @@ also:
   </section>
 
   <section>
-    <h2 id="single-panel-accordion">Single Panel Accordion</h2>
-    <p>
-      By setting the <code>current-panel</code> attribute on an accordion, it
-      will be placed into "single-panel" mode. In this configuration, a user
-      will only be able to expand one panel at a time.
-    </p>
+    <header>
+      <h2 id="single-panel-accordion">Single Panel Accordion</h2>
+      <p>
+        By setting the <code>current-panel</code> attribute on an accordion, it
+        will be placed into "single-panel" mode. In this configuration, a user
+        will only be able to expand one panel at a time.
+      </p>
+    </header>
+
     <div class="example" id="vue-singlePanelAccordionDemo" v-cloak>
       <header>
         <form class="beta-hxForm">

--- a/docs/components/alerts/index.html
+++ b/docs/components/alerts/index.html
@@ -6,43 +6,82 @@ also:
   elements/hx-alert: <hx-alert>
 ---
 {% extends 'component.njk' %}
+
+{% block page_header %}
+  <p>
+    An alert provides users with a contextual message relating to a user action and
+    may provide an optional call to action (CTA) button that can be used to trigger
+    additional behavior, if desired.
+  </p>
+{% endblock %}
+
 {% block content %}
   <section>
-    <h2 id="basic-alert">Basic Alert</h2>
-    <p class="comfortable">
-      An alert provides users with a contextual message relating to a user action and
-      may provide an optional call to action (CTA) button that can be used to trigger
-      additional behavior, if desired.
-    </p>
+    <header>
+      <h2 id="basic-alert">Basic Alert</h2>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example" id="vue-alertDemo" v-cloak>
       <header>
         <form class="beta-hxForm">
-          <div>
-            <label for="selType" class="beta-hxFieldName">Type</label>
+          <hx-select-control>
             <select id="selType" v-model="type">
               <option v-for="_type in types" :value="_type">
-                {% raw %}{{ _type.label }}{% endraw %}
+                {% raw %}{{_type.label}}{% endraw %}
               </option>
             </select>
-          </div>
-          <p>
-            <label for="txtStatus" class="beta-hxFieldName">Status</label>
-            <input id="txtStatus" class="hxTextCtrl" v-model="status" />
-          </p>
-          <p>
-            <label for="txtCta" class="beta-hxFieldName">CTA</label>
-            <input id="txtCta" class="hxTextCtrl" v-model="cta" />
-          </p>
-          <p>
-            <label for="txtContent" class="beta-hxFieldName">Content</label>
-            <textarea id="txtContent" class="hxTextCtrl" v-model="content"></textarea>
-          </p>
+            <hx-select></hx-select>
+            <label for="selType">
+              Type
+            </label>
+          </hx-select-control>
+
+          <hx-text-control>
+            <input
+              id="txtStatus"
+              type="text"
+              v-model="status"
+            />
+            <label for="txtStatus">
+              Status
+            </label>
+          </hx-text-control>
+
+          <hx-text-control>
+            <input
+              id="txtCta"
+              type="text"
+              v-model="cta"
+            />
+            <label for="txtCta">
+              CTA
+            </label>
+          </hx-text-control>
+
+          <hx-textarea-control>
+            <textarea
+              id="txtContent"
+              v-model="content"
+            ></textarea>
+            <label for="txtContent">
+              Content
+            </label>
+          </hx-textarea-control>
+
           <fieldset>
             <legend class="beta-hxFieldName">Options</legend>
-            <div>
-              <input id="chkIsPersistent" type="checkbox" v-model="isPersistent">
-              <label for="chkIsPersistent">Persist</label>
-            </div>
+            <hx-checkbox-control>
+              <input
+                id="chkIsPersistent"
+                type="checkbox"
+                v-model="isPersistent"
+              />
+              <label for="chkIsPersistent">
+                <hx-checkbox></hx-checkbox>
+                Persist
+              </label>
+            </hx-checkbox-control>
           </fieldset>
         </form>
       </header>

--- a/docs/components/badges/index.html
+++ b/docs/components/badges/index.html
@@ -5,8 +5,8 @@ also:
   guides/react-compatibility/#significant-white-space: Significant White Space (React Compatibility)
   components/badges/test.html: Testing - Badges
 ---
-{% set contentClasses = 'docs-badge' %}
 {% extends 'component.njk' %}
+{% set contentClasses = 'docs-badge' %}
 
 {% block page_header %}
   <p>

--- a/docs/components/box/index.html
+++ b/docs/components/box/index.html
@@ -8,23 +8,30 @@ also:
   elements/hx-div: <hx-div>
 ---
 {% extends 'component.njk' %}
+
+{% block page_header %}
+  <p>
+    The box component provides a set of CSS classes to apply
+    padding evenly around the inside of an element.
+  </p>
+{% endblock %}
+
 {% block content %}
   <section>
-    <p>
-      The box component provides a set of CSS classes to apply
-      padding evenly around the inside of an element.
-    </p>
-  </section>
+    <header>
+      <h2 id="containers">Containers</h2>
+      {# TODO: add section description #}
+    </header>
 
-  <section>
-    <h2 id="containers">Containers</h2>
     <p>
       Containers can be defined in one of two ways:
     </p>
+
     <ol class="hxList">
       <li>Using an <code>&lt;hx-div&gt;</code> element <em class="hxSubBody">(recommended)</em></li>
       <li>Adding the <code>.hxBox</code> CSS class to any block element</li>
     </ol>
+
     <div class="example">
       <div class="box-demo">
         <hx-div>hx-div</hx-div>
@@ -38,6 +45,7 @@ also:
         {% endcode %}
       </footer>
     </div>
+
     <p class="hxSubdued hxSubBody">
       <hx-icon type="info-circle"></hx-icon>
       Visual styling added for demonstration purposes.
@@ -45,24 +53,28 @@ also:
   </section>
 
   <section>
-    <h2 id="spacing">Spacing</h2>
-    <p>
-      Spacing is applied evenly around the inside of a container by
-      adding one of the supported CSS classes to your container element.
-    </p>
+    <header>
+      <h2 id="spacing">Spacing</h2>
+      <p>
+        Spacing is applied evenly around the inside of a container by
+        adding one of the supported CSS classes to your container element.
+      </p>
+    </header>
+
     <div class="example" id="vue-boxDemo" v-cloak>
       <header>
         <form class="beta-hxForm">
-          <div>
-            <label for="selSpacing" class="beta-hxFieldName">Spacing</label>
+          <hx-select-control>
             <select id="selSpacing" v-model="spacing">
-              <option
-                v-for="_spacing in spacings"
-                v-text="_spacing.label"
-                :value="_spacing"
-              ></option>
+              <option v-for="_spacing in spacings" :value="_spacing">
+                {% raw %}{{_spacing.label}}{% endraw %}
+              </option>
             </select>
-          </div>
+            <hx-select></hx-select>
+            <label for="selSpacing">
+              Spacing
+            </label>
+          </hx-select-control>
         </form>
       </header>
 
@@ -86,16 +98,18 @@ also:
           {% endcode %}
         </template>
         <template v-else>
-          {% code 'html' %}{% raw %}
-            <div class="hxBox"></div>{% endraw %}
+          {% code 'html' %}
+            <div class="hxBox"></div>
           {% endcode %}
         </template>
       </footer>
     </div>
+
     <p class="hxSubdued hxSubBody">
       <hx-icon type="info-circle"></hx-icon>
       Visual styling added for demonstration purposes.
     </p>
+
     <table class="hxTable hxTable--condensed">
       <thead>
         <tr>
@@ -153,23 +167,29 @@ also:
   </section>
 
   <section>
-    <h2 id="scrolling-containers">Scrolling Containers</h2>
+    <header>
+      <h2 id="scrolling-containers">Scrolling Containers</h2>
+      {# TODO: add section description #}
+    </header>
+
     <hx-alert type="warning" persist>
       Scrolling containers must be implemented using the
       <code>&lt;hx-div&gt;</code> element in order to reliably calculate
       coordinates of absolutely positioned elements.
     </hx-alert>
+
     <p>
       Scrolling containers are defined by setting the value of an
       <code>&lt;hx-div&gt;</code> element's <code>scroll</code> attribute
       to one of the directions demonstrated below.
     </p>
+
     <div class="example" id="vue-scrollBoxDemo" v-cloak>
       <header>
         <form class="beta-hxForm">
           <fieldset>
             <legend class="beta-hxFieldName">Scroll Direction</legend>
-            <div v-for="(_direction, idx) in directions">
+            <hx-radio-control v-for="(_direction, idx) in directions">
               <input
                 :id="'radDirection' + idx"
                 :value="_direction"
@@ -177,15 +197,26 @@ also:
                 type="radio"
                 v-model="direction"
               />
-              <label :for="'radDirection' + idx" v-text="_direction"></label>
-            </div>
+              <label :for="'radDirection' + idx">
+                <hx-radio></hx-radio>
+                {% raw %}{{_direction}}{% endraw %}
+              </label>
+            </hx-radio-control>
           </fieldset>
+
           <fieldset>
             <legend class="beta-hxFieldName">Options</legend>
-            <div>
-              <input id="chkLogEvents" type="checkbox" v-model="isListening" />
-              <label for="chkLogEvents">Log events to console</label>
-            </div>
+            <hx-checkbox-control>
+              <input
+                id="chkLogEvents"
+                type="checkbox"
+                v-model="isListening"
+              />
+              <label for="chkLogEvents">
+                <hx-checkbox></hx-checkbox>
+                Log events to console
+              </label>
+            </hx-checkbox-control>
           </fieldset>
         </form>
       </header>

--- a/docs/components/breadcrumbs/index.html
+++ b/docs/components/breadcrumbs/index.html
@@ -3,20 +3,20 @@ title: Breadcrumbs
 minver: 0.1.0
 ---
 {% extends 'component.njk' %}
+
+{% block page_header %}
+  <p>
+    Breadcrumbs are simply hyperlinks separated by icon delimiters
+    within a navigation.
+  </p>
+{% endblock %}
+
 {% block content %}
-  <hx-alert type="warning" status="WARNING" persist>
-    The last breadcrumb hyperlink is styled to prevent mouse clicks, but it will not prevent keyboard activation.
-  </hx-alert>
-
   <section>
-    <p>
-      Breadcrumbs are simply hyperlinks separated by icon delimiters
-      within a navigation.
-    </p>
-  </section>
-
-  <section>
-    <h2 id="single-breadcrumb">Single Breadcrumb</h2>
+    <header>
+      <h2 id="single-breadcrumb">Single Breadcrumb</h2>
+      {# TODO: add section description #}
+    </header>
     <p>
       Build breadcrumb navigation by adding the <code>.hxBreadcrumb</code>
       CSS class to a <code>&lt;nav&gt;</code> element that contains at least one
@@ -40,7 +40,10 @@ minver: 0.1.0
   </section>
 
   <section>
-    <h2 id="multiple-breadcrumbs">Multiple Breadcrumbs</h2>
+    <header>
+      <h2 id="multiple-breadcrumbs">Multiple Breadcrumbs</h2>
+      {# TODO: add section description #}
+    </header>
     <p>
       Icon delimiters are added between each hyperlink using the <code>angle-right</code>
       icon with the <code>.delimiter</code> CSS class applied.
@@ -68,5 +71,18 @@ minver: 0.1.0
         {% endcode %}
       </footer>
     </div>
+  </section>
+
+  <section>
+    <header>
+      <h2 id="accessibility">Accessibility</h2>
+    </header>
+
+    <ul class="hxList">
+      <li>
+        The last breadcrumb hyperlink is styled to prevent <i>mouse clicks</i>
+        (doesn't prevent keyboard activation).
+      </li>
+    </ul>
   </section>
 {% endblock %}

--- a/docs/components/buttons/index.html
+++ b/docs/components/buttons/index.html
@@ -10,19 +10,27 @@ also:
   components/reveals: Reveals
 ---
 {% extends 'component.njk' %}
+
+{% block page_header %}
+  <p>
+    Buttons enable users to trigger actions on the current page.
+  </p>
+{% endblock %}
+
 {% block content %}
   <section>
-    <p>
-      Buttons enable users to trigger actions on the current page.
-    </p>
-  </section>
+    <header>
+      <h2 id="basic-button">Basic Button</h2>
+      <p>
+        Define a basic button by adding the <code>.hxBtn</code>
+        CSS class to any supported element.
+      </p>
+    </header>
 
-  <section>
-    <h2 id="basic-button">Basic Button</h2>
     <p>
-      Define a basic button by adding the <code>.hxBtn</code>
-      CSS class to any of the following elements:
+      Supported elements are as follows:
     </p>
+
     <ul class="hxList">
       <li><code>&lt;button&gt;</code></li>
       <li><code>&lt;a href="..."&gt;</code></li>
@@ -30,12 +38,13 @@ also:
       <li><code>&lt;input type="reset"&gt;</code></li>
       <li><code>&lt;input type="submit"&gt;</code></li>
     </ul>
+
     <div class="example" id="vue-basicButtonDemo" v-cloak>
       <header>
         <form class="beta-hxForm">
           <fieldset>
             <legend class="beta-hxFieldName">Variant</legend>
-            <div v-for="(_variant, idx) in variants">
+            <hx-radio-control v-for="(_variant, idx) in variants">
               <input
                 :id="'radBasicVariant' + idx"
                 :value="_variant"
@@ -44,14 +53,16 @@ also:
                 v-model="variant"
               />
               <label :for="'radBasicVariant' + idx">
-                <span v-text="_variant.label"></span>
-                <em class="hxSubBody" v-if="_variant.default">(default)</em>
+                <hx-radio></hx-radio>
+                {% raw %}{{_variant.label}}{% endraw %}
               </label>
-            </div>
+              <p v-if="_variant.default">(default)</p>
+            </hx-radio-control>
           </fieldset>
+
           <fieldset>
             <legend class="beta-hxFieldName">Size</legend>
-            <div v-for="(_size, idx) in sizes">
+            <hx-radio-control v-for="(_size, idx) in sizes">
               <input
                 :id="'radBasicSize' + idx"
                 :value="_size"
@@ -60,10 +71,11 @@ also:
                 v-model="size"
               />
               <label :for="'radBasicSize' + idx">
-                <span v-text="_size.label"></span>
-                <em class="hxSubBody" v-if="_size.default">(default)</em>
+                <hx-radio></hx-radio>
+                {% raw %}{{_size.label}}{% endraw %}
               </label>
-            </div>
+              <p v-if="_size.default">(default)</p>
+            </hx-radio-control>
           </fieldset>
         </form>
       </header>
@@ -109,27 +121,37 @@ also:
         {% endcode %}
       </footer>
     </div>
-    <p class="hxSubBody hxSubdued">
-      <hx-icon type="info-circle"></hx-icon>
-      Text nodes within buttons <i>must</i> be wrapped in a <code>&lt;span&gt;</code>,
-      if non-text siblings are present.
-    </p>
+
+    <footer>
+      <p class="hxSubBody hxSubdued">
+        <hx-icon type="info-circle"></hx-icon>
+        Text nodes within buttons <i>must</i> be wrapped in a <code>&lt;span&gt;</code>,
+        if non-text siblings are present.
+      </p>
+    </footer>
   </section>
 
   <section>
-    <h2 id="button-group">Button Group</h2>
-    <p class="comfortable">
-      A button group is built by placing several buttons within a <code>&lt;div&gt;</code>
-      element having the <code>.hxBtnGroup</code> CSS class. Button variant classes are added
-      to the wrapper instead of the individual buttons to apply the same style to all buttons
-      in the group.
+    <header>
+      <h2 id="button-group">Button Group</h2>
+      <p>
+        A button group is built by placing several buttons within a
+        <code>&lt;div&gt;</code> element having the <code>.hxBtnGroup</code>
+        CSS class.
+      </p>
+    </header>
+
+    <p>
+      Button variant classes are added to the wrapper instead of the individual
+      buttons in order to apply the same style to all buttons within the group.
     </p>
+
     <div class="example" id="vue-buttonGroupDemo" v-cloak>
       <header>
         <form class="beta-hxForm">
           <fieldset>
             <legend class="beta-hxFieldName">Variant</legend>
-            <div v-for="(_variant, idx) in variants">
+            <hx-radio-control v-for="(_variant, idx) in variants">
               <input
                 :id="'radGroupVariant' + idx"
                 :value="_variant"
@@ -138,14 +160,16 @@ also:
                 v-model="variant"
               />
               <label :for="'radGroupVariant' + idx">
-                <span v-text="_variant.label"></span>
-                <em class="hxSubBody" v-if="_variant.default">(default)</em>
+                <hx-radio></hx-radio>
+                {% raw %}{{_variant.label}}{% endraw %}
               </label>
-            </div>
+              <p v-if="_variant.default">(default)</p>
+            </hx-radio-control>
           </fieldset>
+
           <fieldset>
             <legend class="beta-hxFieldName">Size</legend>
-            <div v-for="(_size, idx) in sizes">
+            <hx-radio-control v-for="(_size, idx) in sizes">
               <input
                 :id="'radGroupSize' + idx"
                 :value="_size"
@@ -154,10 +178,11 @@ also:
                 v-model="size"
               />
               <label :for="'radGroupSize' + idx">
-                <span v-text="_size.label"></span>
-                <em class="hxSubBody" v-if="_size.default">(default)</em>
+                <hx-radio></hx-radio>
+                {% raw %}{{_size.label}}{% endraw %}
               </label>
-            </div>
+              <p v-if="_size.default">(default)</p>
+            </hx-radio-control>
           </fieldset>
         </form>
       </header>
@@ -174,7 +199,7 @@ also:
 
       <footer>
         {% code 'html' %}{% raw %}
-          <div class="{{ classes }}">
+          <div class="{{classes}}">
             <button class="hxBtn">First</button>
             <button class="hxBtn">Second</button>
             <button class="hxBtn">

--- a/docs/components/checkboxes/index.html
+++ b/docs/components/checkboxes/index.html
@@ -7,48 +7,83 @@ also:
   elements/hx-checkbox: <hx-checkbox>
 ---
 {% extends 'component.njk' %}
+
+{% block page_header %}
+  {# TODO: add component description #}
+{% endblock %}
+
 {% block content %}
   <section>
-    <h2 id="basic-checkbox">Basic Checkbox</h2>
+    <header>
+      <h2 id="basic-checkbox">Basic Checkbox</h2>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example" id="vue-checkboxDemo" v-cloak>
       <header>
         <form class="beta-hxForm">
-          <p>
-            <label for="txtLabel">Label</label>
-            <input id="txtLabel" class="hxTextCtrl" v-model="label" />
-          </p>
+          <hx-text-control>
+            <input
+              id="txtLabel"
+              type="text"
+              v-model="label"
+            />
+            <label for="txtLabel">
+              Label
+            </label>
+          </hx-text-control>
+
           <fieldset>
             <legend class="beta-hxFieldName">Options</legend>
             <hx-checkbox-control>
-              <input id="chkIsChecked" type="checkbox" v-model="isChecked" />
+              <input
+                id="chkIsChecked"
+                type="checkbox"
+                v-model="isChecked"
+              />
               <label for="chkIsChecked">
                 <hx-checkbox></hx-checkbox>
                 Checked
               </label>
             </hx-checkbox-control>
+
             <hx-checkbox-control>
-              <input id="chkIsDisabled" type="checkbox" v-model="isDisabled" />
+              <input
+                id="chkIsDisabled"
+                type="checkbox"
+                v-model="isDisabled"
+              />
               <label for="chkIsDisabled">
                 <hx-checkbox></hx-checkbox>
                 Disabled
               </label>
             </hx-checkbox-control>
+
             <hx-checkbox-control>
-              <input id="chkIndeterminate" type="checkbox" v-model="isIndeterminate" />
+              <input
+                id="chkIndeterminate"
+                type="checkbox"
+                v-model="isIndeterminate"
+              />
               <label for="chkIndeterminate">
                 <hx-checkbox></hx-checkbox>
                 Indeterminate
               </label>
-              {% raw %}
               <p>
                 <code>
-                  (el.indeterminate = {{ isIndeterminate }})
+                  {% raw %}
+                  (el.indeterminate = {{isIndeterminate}})
+                  {% endraw %}
                 </code>
               </p>
-              {% endraw %}
             </hx-checkbox-control>
+
             <hx-checkbox-control>
-              <input id="chkRequired" type="checkbox" v-model="isRequired" />
+              <input
+                id="chkRequired"
+                type="checkbox"
+                v-model="isRequired"
+              />
               <label for="chkRequired">
                 <hx-checkbox></hx-checkbox>
                 Required
@@ -57,6 +92,7 @@ also:
           </fieldset>
         </form>
       </header>
+
       <div>
         <hx-checkbox-control>
           <input
@@ -73,6 +109,7 @@ also:
           </label>
         </hx-checkbox-control>
       </div>
+
       <footer>
         <pre><code v-text="snippet"></code></pre>
       </footer>

--- a/docs/components/choice-tiles/index.html
+++ b/docs/components/choice-tiles/index.html
@@ -6,53 +6,112 @@ also:
   elements/hx-tile: <hx-tile>
 ---
 {% extends 'component.njk' %}
+
+{% block page_header %}
+  {# TODO: add component description #}
+{% endblock %}
+
 {% block content %}
   <section>
-    <h2 id="basic-choice-tile">Basic Choice Tile</h2>
+    <header>
+      <h2 id="basic-choice-tile">Basic Choice Tile</h2>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example" id="vue-choiceDemo" v-cloak>
       <header>
         <form class="beta-hxForm">
-          <div>
-            <label for="selSize" class="beta-hxFieldName">Size</label>
+          <hx-select-control>
             <select id="selSize" v-model="size">
               <option v-for="_size in sizes" :value="_size">
-                {% raw %}{{ _size.label }}{% endraw %}
+                {% raw %}{{_size.label}}{% endraw %}
               </option>
             </select>
-          </div>
-          <p>
-            <label for="txtTitle" class="beta-hxFieldName">Title</label>
-            <input id="txtTitle" class="hxTextCtrl" v-model="title" />
-          </p>
-          <p>
-            <label for="txtDescription" class="beta-hxFieldName">Description</label>
-            <textarea id="txtDescription" class="hxTextCtrl" v-model="description"></textarea>
-          </p>
+            <hx-select></hx-select>
+            <label for="selSize">
+              Size
+            </label>
+          </hx-select-control>
+
+          <hx-text-control>
+            <input
+              id="txtTitle"
+              type="text"
+              v-model="title"
+            />
+            <label for="txtTitle">
+              Title
+            </label>
+          </hx-text-control>
+
+          <hx-textarea-control>
+            <textarea
+              id="txtDescription"
+              v-model="description"
+            ></textarea>
+            <label for="txtDescription">
+              Description
+            </label>
+          </hx-textarea-control>
+
           <fieldset>
             <legend class="beta-hxFieldName">Options</legend>
-            <div>
-              <input id="chkIsChecked" type="checkbox" v-model="isChecked" />
-              <label for="chkIsChecked">Checked</label>
-            </div>
-            <div>
-              <input id="chkIsDisabled" type="checkbox" v-model="isDisabled" />
-              <label for="chkIsDisabled">Disabled</label>
-            </div>
-            <div>
-              <input id="chkIsInvalid" type="checkbox" v-model="isInvalid" />
-              <label for="chkIsInvalid">Invalid</label>
-            </div>
-            <div>
-              <input id="chkIsSubdued" type="checkbox" v-model="isSubdued" />
-              <label for="chkIsSubdued">Subdued</label>
-            </div>
+            <hx-checkbox-control>
+              <input
+                id="chkIsChecked"
+                type="checkbox"
+                v-model="isChecked"
+              />
+              <label for="chkIsChecked">
+                <hx-checkbox></hx-checkbox>
+                Checked
+              </label>
+            </hx-checkbox-control>
+
+            <hx-checkbox-control>
+              <input
+                id="chkIsDisabled"
+                type="checkbox"
+                v-model="isDisabled"
+              />
+              <label for="chkIsDisabled">
+                <hx-checkbox></hx-checkbox>
+                Disabled
+              </label>
+            </hx-checkbox-control>
+
+            <hx-checkbox-control>
+              <input
+                id="chkIsInvalid"
+                type="checkbox"
+                v-model="isInvalid"
+              />
+              <label for="chkIsInvalid">
+                <hx-checkbox></hx-checkbox>
+                Invalid
+              </label>
+            </hx-checkbox-control>
+
+            <hx-checkbox-control>
+              <input
+                id="chkIsSubdued"
+                type="checkbox"
+                v-model="isSubdued"
+              />
+              <label for="chkIsSubdued">
+                <hx-checkbox></hx-checkbox>
+                Subdued
+              </label>
+            </hx-checkbox-control>
           </fieldset>
         </form>
       </header>
 
       <div class="choice-tile-demo">
         <label class="hxChoice">
-          <input type="radio" name="foo"
+          <input
+            name="foo"
+            type="radio"
             :checked="isChecked"
             :disabled="isDisabled"
             :invalid="isInvalid"
@@ -63,8 +122,10 @@ also:
             <div class="hx-tile-icon">
               <hx-icon type="account"></hx-icon>
             </div>
-            <header v-text="title"></header>
-            <p v-text="description"></p>
+            {% raw %}
+            <header>{{title}}</header>
+            <p>{{description}}</p>
+            {% endraw %}
           </hx-tile>
         </label>
       </div>
@@ -76,7 +137,11 @@ also:
   </section>
 
   <section>
-    <h2 id="option-grid">Option Grid</h2>
+    <header>
+      <h2 id="option-grid">Option Grid</h2>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example">
       <div>
         <div class="hxRow">

--- a/docs/components/dropdown-select/index.html
+++ b/docs/components/dropdown-select/index.html
@@ -7,8 +7,9 @@ also:
   elements/hx-select: <hx-select>
 ---
 {% extends 'component.njk' %}
+
 {% block page_header %}
-  <p class="comfortable">
+  <p>
     The {{page.title}} component provides markup to define a single-selection,
     drop-down list control (commonly used in forms).
   </p>
@@ -16,26 +17,27 @@ also:
 
 {% block content %}
   <section>
-    <h2 id="basic-select">Basic Select</h2>
+    <header>
+      <h2 id="basic-select">Basic Select</h2>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example" id="vue-selectDemo" v-cloak>
       <header>
         <form class="beta-hxForm">
-          <div>
-            <hx-text-control>
-              <input
-                id="txtLabel"
-                type="text"
-                v-model="label"
-              />
-              <label for="txtLabel">
-                Label Text
-              </label>
-            </hx-text-control>
-          </div>
+          <hx-text-control>
+            <input
+              id="txtLabel"
+              type="text"
+              v-model="label"
+            />
+            <label for="txtLabel">
+              Label Text
+            </label>
+          </hx-text-control>
 
           <fieldset>
             <legend class="beta-hxFieldName">Label Annotation</legend>
-
             <hx-checkbox-control>
               <input
                 id="chkHasAsterisk"
@@ -108,9 +110,10 @@ also:
           <hx-select></hx-select>
           <label
             for="selDemo"
-            v-text="label"
             :class="{ hxOptional: hasOptional, hxRequired: hasAsterisk }"
-          ></label>
+          >
+            {% raw %}{{label}}{% endraw %}
+          </label>
         </hx-select-control>
       </div>
 
@@ -124,12 +127,11 @@ also:
     </div>
   </section>
 
-  <!--
-    TODO:
+  {# TODO:
     Need centralized documentation of HelixUI form control validation behavior.
   <section>
     <h2 id="validation">Validation</h2>
-    <p class="comfortable">
+    <p>
       A {{page.title}} is designed to take advantage of standardized
       <a href="https://mzl.la/2SuKTmv">HTML form validation</a> capabilities.
     </p>
@@ -145,5 +147,5 @@ also:
       to apply invalid control styles.
     </p>
   </section>
-  -->
+  #}
 {% endblock %}

--- a/docs/components/files/index.html
+++ b/docs/components/files/index.html
@@ -13,18 +13,29 @@ also:
   elements/hx-file-tile: <hx-file-tile>
 ---
 {% extends 'component.njk' %}
+
+{% block page_header %}
+  {# TODO: add component description #}
+{% endblock %}
+
 {% block content %}
   <section>
-    <h2 id="drop-zone">Drop Zone</h2>
-    <p class="hxSubBody">Added: v0.14.0</p>
+    <header>
+      <h2 id="drop-zone">Drop Zone</h2>
+      <p class="hxSubBody">Added: v0.14.0</p>
+      {# TODO: add section description #}
+    </header>
+
     <p>
       A container that provides a visual overlay when dragging a file, marking
       the boundaries of where a user can drop.
     </p>
+
     <p class="hxSubdued hxSubBody">
       <hx-icon type="info-circle"></hx-icon>
       The drop zone ignores any padding applied to it.
     </p>
+
     <div class="example" id="vue-dropZoneDemo">
       <div>
         <hx-drop-zone @drop.prevent="onDrop">
@@ -61,14 +72,29 @@ also:
   </section>
 
   <section>
-    <h2 id="file-selector">File Selector</h2>
-    <p class="hxSubBody">Added: v0.13.0</p>
+    <header>
+      <h2 id="file-selector">File Selector</h2>
+      <p class="hxSubBody">Added: v0.13.0</p>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example" id="vue-fileInputDemo" v-cloak>
       <header>
         <form class="beta-hxForm">
+          <hx-text-control>
+            <input
+              id="txtLabel"
+              type="text"
+              v-model="label"
+            />
+            <label for="txtLabel">
+              Label
+            </label>
+          </hx-text-control>
+
           <fieldset>
-            <legend class="beta-hxFieldName">Variant</legend>
-            <div v-for="(_variant, idx) in variants">
+            <legend class="beta-hxFieldName">Button Variant</legend>
+            <hx-radio-control v-for="(_variant, idx) in variants">
               <input
                 :id="'radSelectorVariant' + idx"
                 :value="_variant"
@@ -77,14 +103,16 @@ also:
                 v-model="variant"
               />
               <label :for="'radSelectorVariant' + idx">
-                <span v-text="_variant.label"></span>
-                <em class="hxSubBody" v-if="_variant.default">(default)</em>
+                <hx-radio></hx-radio>
+                {% raw %}{{_variant.label}}{% endraw %}
               </label>
-            </div>
+              <p v-if="_variant.default">(default)</p>
+            </hx-radio-control>
           </fieldset>
+
           <fieldset>
             <legend class="beta-hxFieldName">Icon</legend>
-            <div v-for="(_icon, idx) in icons">
+            <hx-radio-control v-for="(_icon, idx) in icons">
               <input
                 :id="'radSelectorIcon' + idx"
                 :value="_icon"
@@ -92,33 +120,43 @@ also:
                 type="radio"
                 v-model="icon"
               />
-              <label
-                :for="'radSelectorIcon' + idx"
-                v-text="_icon"
-              ></label>
-            </div>
+              <label :for="'radSelectorIcon' + idx">
+                <hx-radio></hx-radio>
+                {% raw %}{{_icon}}{% endraw %}
+              </label>
+            </hx-radio-control>
           </fieldset>
-          <p>
-            <label for="txtLabel" class="beta-hxFieldName">Label</label>
-            <input id="txtLabel" class="hxTextCtrl" v-model="label" />
-          </p>
+
           <fieldset>
-            <legend class="beta-hxFieldName">Options</legend>
-            <div>
-              <input id="chkIsMultiple" type="checkbox" v-model="isMultiple">
-              <label for="chkIsMultiple">Multiple</label>
-            </div>
+            <legend class="beta-hxFieldName">Control Options</legend>
+            <hx-checkbox-control>
+              <input
+                id="chkIsMultiple"
+                type="checkbox"
+                v-model="isMultiple"
+              />
+              <label for="chkIsMultiple">
+                <hx-checkbox></hx-checkbox>
+                Multiple
+              </label>
+            </hx-checkbox-control>
           </fieldset>
         </form>
       </header>
+
       <div>
         <hx-file-input
           :class="variant.val"
           :icon="icon"
-          :label="label">
-          <input type="file" :multiple="isMultiple" />
+          :label="label"
+        >
+          <input
+            type="file"
+            :multiple="isMultiple"
+          />
         </hx-file-input>
       </div>
+
       <footer>
         <pre><code v-text="snippet"></code></pre>
       </footer>
@@ -126,58 +164,128 @@ also:
   </section>
 
   <section>
-    <h2 id="file-tile">File Tile</h2>
-    <p class="hxSubBody">Added: v0.12.0</p>
+    <header>
+      <h2 id="file-tile">File Tile</h2>
+      <p class="hxSubBody">Added: v0.12.0</p>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example" id="vue-fileTileDemo" v-cloak>
       <header>
         <form class="beta-hxForm">
-          <fieldset>
-            <legend class="beta-hxFieldName">States</legend>
-            <div>
-              <input id="radTileDownloadable" type="radio" value="downloadable" name="file-state" v-model="state" />
-              <label for="radTileDownloadable">Downloadable</label>
-            </div>
-            <div>
-              <input id="radTileLoading" type="radio" value="loading" name="file-state" v-model="state" />
-              <label for="radTileLoading">Loading</label>
-            </div>
-            <div>
-              <input id="radTileInvalid" type="radio" value="invalid" name="file-state" v-model="state" />
-              <label for="radTileInvalid">Invalid</label>
-            </div>
-          </fieldset>
-          <div>
-            <label for="selIcon" class="beta-hxFieldName">Icon</label>
+          <hx-text-control>
+            <input
+              id="txtName"
+              type="text"
+              v-model="name"
+            />
+            <label for="txtName">
+              Name
+            </label>
+          </hx-text-control>
+
+          <hx-select-control>
             <select id="selIcon" v-model="icon">
-              <option v-for="_icon in icons" :value="_icon" v-text="_icon">
+              <option v-for="_icon in icons" :value="_icon">
+                {% raw %}{{_icon}}{% endraw %}
               </option>
             </select>
-          </div>
-          <p>
-            <label for="txtName" class="beta-hxFieldName">Name</label>
-            <input id="txtName" class="hxTextCtrl" v-model="name" />
-          </p>
+            <hx-select></hx-select>
+            <label for="selIcon">
+              Icon
+            </label>
+          </hx-select-control>
+
+          <fieldset>
+            <legend class="beta-hxFieldName">State</legend>
+            <hx-radio-control>
+              <input
+                id="radTileDownloadable"
+                name="file-state"
+                type="radio"
+                v-model="state"
+                value="downloadable"
+              />
+              <label for="radTileDownloadable">
+                <hx-radio></hx-radio>
+                Downloadable
+              </label>
+            </hx-radio-control>
+
+            <hx-radio-control>
+              <input
+                id="radTileLoading"
+                name="file-state"
+                type="radio"
+                v-model="state"
+                value="loading"
+              />
+              <label for="radTileLoading">
+                <hx-radio></hx-radio>
+                Loading
+              </label>
+            </hx-radio-control>
+
+            <hx-radio-control>
+              <input
+                id="radTileInvalid"
+                name="file-state"
+                type="radio"
+                v-model="state"
+                value="invalid"
+              />
+              <label for="radTileInvalid">
+                <hx-radio></hx-radio>
+                Invalid
+              </label>
+            </hx-radio-control>
+          </fieldset>
+
           <template v-if="isDownloadable">
-            <p>
-              <label for="txtHref" class="beta-hxFieldName">HREF</label>
-              <input id="txtHref" class="hxTextCtrl" v-model="href" />
-            </p>
-            <p>
-              <label for="txtDetails" class="beta-hxFieldName">Details</label>
-              <input id="txtDetails" class="hxTextCtrl" v-model="details" />
-            </p>
+            <hx-text-control>
+              <input
+                id="txtHref"
+                type="text"
+                v-model="href"
+              />
+              <label for="txtHref">
+                HREF
+              </label>
+            </hx-text-control>
+
+            <hx-text-control>
+              <input
+                id="txtDetails"
+                type="text"
+                v-model="details"
+              />
+              <label for="txtDetails">
+                Details
+              </label>
+            </hx-text-control>
+
             <fieldset>
-              <legend class="beta-hxFieldName">Options</legend>
-              <div>
-                <input id="chkTileReadOnly" type="checkbox" v-model="readonly" />
-                <label for="chkTileReadOnly">Readonly</label>
-              </div>
+              <legend class="beta-hxFieldName">Tile Options</legend>
+              <hx-checkbox-control>
+                <input
+                  id="chkTileReadOnly"
+                  type="checkbox"
+                  v-model="readonly"
+                />
+                <label for="chkTileReadOnly">
+                  <hx-checkbox></hx-checkbox>
+                  Readonly
+                </label>
+              </hx-checkbox-control>
             </fieldset>
           </template>
-          <p v-if="isLoading">
-            <label for="rngProgress" class="beta-hxFieldName">Progress</label>
-            <input id="rngProgress" type="range" v-model="progress"/>
-          </p>
+
+          <template v-if="isLoading">
+            <div>
+              <label for="rngProgress" class="beta-hxFieldName">Progress</label>
+              <input id="rngProgress" type="range" v-model="progress"/>
+            </div>
+          </template>
         </form>
       </header>
 

--- a/docs/components/grid/index.html
+++ b/docs/components/grid/index.html
@@ -6,540 +6,557 @@ also:
   components/layouts: Layouts
 ---
 {% extends 'component.njk' %}
-{% block content %}
-<section>
-  <hx-alert type="warning" status="warning" persist>
-    HelixUI grid classes are not compatible with Bootstrap grid styles.
-  </hx-alert>
 
+{% block page_header %}
   <p>
-    The Grid CSS module provides utility classes based on flexbox to help
-    with the positioning and layout of content within containers.
+    The Grid component provides CSS utility classes based on
+    <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout" target="_blank">
+      CSS Flexible Box Layout
+    </a>
+    to help with arranging content within containers.
   </p>
-</section>
+{% endblock %}
 
-<section><!-- rows -->
-  <h2 id="rows">Rows</h2>
-  <ul class="hxList">
-    <li>
-      Rows are containers that allow you to divide their
-      <em>width</em> amongst their children.
-    </li>
-  </ul>
-  <div class="example">
-    <div class="grid-demo">
+{% block content %}
+  <section><!-- rows -->
+    <header>
+      <h2 id="rows">Rows</h2>
       <p>
-        It was discovered that by rarely reviewing the VOC meetings, we can
-        practice the ranked XP task for the agile branch. If it takes you too
-        long to join the viable XP manifesto, then you are not burning out enough.
+        Rows are containers that allow you to divide their
+        <em>width</em> amongst their children.
       </p>
-      <div class="hxRow">
-        <div class="hxCol"><p>Column 1 of 3</p></div>
-        <div class="hxCol"><p>Column 2 of 3</p></div>
-        <div class="hxCol"><p>Column 3 of 3</p></div>
-      </div>
-      <p>
-        Try to commit the burndown standard, maybe it will help join the MVP
-        standards. As a user, I should be able to block the burndown deadline so
-        that I can block the minimum WIP methods near the parallel deadlines.
-      </p>
-    </div>
+    </header>
 
-    <footer>
-      {% code 'html' %}
-        <p>...</p>
+    <div class="example">
+      <div class="grid-demo">
+        <p>
+          It was discovered that by rarely reviewing the VOC meetings, we can
+          practice the ranked XP task for the agile branch. If it takes you too
+          long to join the viable XP manifesto, then you are not burning out enough.
+        </p>
         <div class="hxRow">
           <div class="hxCol"><p>Column 1 of 3</p></div>
           <div class="hxCol"><p>Column 2 of 3</p></div>
           <div class="hxCol"><p>Column 3 of 3</p></div>
         </div>
-        <p>...</p>
-      {% endcode %}
-    </footer>
-  </div>
-</section>
+        <p>
+          Try to commit the burndown standard, maybe it will help join the MVP
+          standards. As a user, I should be able to block the burndown deadline so
+          that I can block the minimum WIP methods near the parallel deadlines.
+        </p>
+      </div>
 
-<section><!-- columns -->
-  <h2 id="columns">Columns</h2>
-  <ul class="hxList">
-    <li>
-      Columns are containers that allow you to divide their
-      <em>height</em> amongst their children.
-    </li>
-    <li>Columns are the basis for all positioned content within a row.</li>
-    <li>
-      Columns <em>share width equally</em> among other columns in the same row.
-    </li>
-  </ul>
-  <div class="example">
-    <div class="grid-demo">
-      <div class="demo-container text-center">
-        <div class="hxRow">
-          <div class="hxCol">1/1</div>
-        </div>
-        <div class="hxRow">
-          <div class="hxCol">1/2</div>
-          <div class="hxCol">2/2</div>
-        </div>
-        <div class="hxRow">
-          <div class="hxCol">1/3</div>
-          <div class="hxCol">2/3</div>
-          <div class="hxCol">3/3</div>
+      <footer>
+        {% code 'html' %}
+          <p>...</p>
+          <div class="hxRow">
+            <div class="hxCol"><p>Column 1 of 3</p></div>
+            <div class="hxCol"><p>Column 2 of 3</p></div>
+            <div class="hxCol"><p>Column 3 of 3</p></div>
+          </div>
+          <p>...</p>
+        {% endcode %}
+      </footer>
+    </div>
+  </section>
+
+  <section><!-- columns -->
+    <header>
+      <h2 id="columns">Columns</h2>
+      <p>
+        Columns are containers that allow you to divide their
+        <em>height</em> amongst their children.
+      </p>
+    </header>
+
+    <ul class="hxList">
+      <li>Columns are the basis for all positioned content within a row.</li>
+      <li>
+        Columns <em>share width equally</em> among other columns in the same row.
+      </li>
+    </ul>
+
+    <div class="example">
+      <div class="grid-demo">
+        <div class="demo-container text-center">
+          <div class="hxRow">
+            <div class="hxCol">1/1</div>
+          </div>
+          <div class="hxRow">
+            <div class="hxCol">1/2</div>
+            <div class="hxCol">2/2</div>
+          </div>
+          <div class="hxRow">
+            <div class="hxCol">1/3</div>
+            <div class="hxCol">2/3</div>
+            <div class="hxCol">3/3</div>
+          </div>
         </div>
       </div>
+
+      <footer>
+        {% code 'html' %}
+          <div class="hxRow">
+            <div class="hxCol">1/1</div>
+          </div>
+          <div class="hxRow">
+            <div class="hxCol">1/2</div>
+            <div class="hxCol">2/2</div>
+          </div>
+          <div class="hxRow">
+            <div class="hxCol">1/3</div>
+            <div class="hxCol">2/3</div>
+            <div class="hxCol">3/3</div>
+          </div>
+        {% endcode %}
+      </footer>
     </div>
+  </section>
 
-    <footer>
-      {% code 'html' %}
-        <div class="hxRow">
-          <div class="hxCol">1/1</div>
-        </div>
-        <div class="hxRow">
-          <div class="hxCol">1/2</div>
-          <div class="hxCol">2/2</div>
-        </div>
-        <div class="hxRow">
-          <div class="hxCol">1/3</div>
-          <div class="hxCol">2/3</div>
-          <div class="hxCol">3/3</div>
-        </div>
-      {% endcode %}
-    </footer>
-  </div>
-</section>
+  <section><!-- column width -->
+    <header>
+      <h2 id="column-width">Column Width</h2>
+      <p>
+        Column width modifiers will set the width of a column container to a
+        predefined percentage of the row width.
+      </p>
+    </header>
 
-<section><!-- column width -->
-  <h2 id="column-width">Column Width</h2>
-  <p>
-    Column width modifiers will set the width of a column container to a
-    predefined percentage of the row width.
-  </p>
-  <p>
-    Use the <code>.hxSpan-{N}</code> modifier (1 &le; N &le; 12) to create
-    columns that are a fraction of a 12-column row width.
-  </p>
-  <ul class="hxList">
-    <li><code>.hxSpan-{N}-{size}</code> responsive classes are available.</li>
-    <li><code>.hxSpan-{N}</code> is shorthand for <code>.hxSpan-{N}-xs</code></li>
-  </ul>
-  <div class="example">
-    <div class="grid-demo">
-      <div class="demo-container text-center">
-        <div class="hxRow">
-          <div class="hxCol hxSpan-12">12</div>
-        </div>
-        <div class="hxRow">
-          <div class="hxCol hxSpan-1">1</div>
-          <div class="hxCol hxSpan-11">11</div>
-        </div>
-        <div class="hxRow">
-          <div class="hxCol hxSpan-2">2</div>
-          <div class="hxCol hxSpan-10">10</div>
-        </div>
-        <div class="hxRow">
-          <div class="hxCol hxSpan-3">3</div>
-          <div class="hxCol hxSpan-9">9</div>
-        </div>
-        <div class="hxRow">
-          <div class="hxCol hxSpan-4">4</div>
-          <div class="hxCol hxSpan-8">8</div>
-        </div>
-        <div class="hxRow">
-          <div class="hxCol hxSpan-5">5</div>
-          <div class="hxCol hxSpan-7">7</div>
-        </div>
-        <div class="hxRow">
-          <div class="hxCol hxSpan-6">6</div>
-          <div class="hxCol hxSpan-6">6</div>
+    <p>
+      Use the <code>.hxSpan-{N}</code> modifier (1 &le; N &le; 12) to create
+      columns that are a fraction of a 12-column row width.
+    </p>
+
+    <ul class="hxList">
+      <li><code>.hxSpan-{N}-{size}</code> responsive classes are available.</li>
+      <li><code>.hxSpan-{N}</code> is shorthand for <code>.hxSpan-{N}-xs</code></li>
+    </ul>
+
+    <div class="example">
+      <div class="grid-demo">
+        <div class="demo-container text-center">
+          <div class="hxRow">
+            <div class="hxCol hxSpan-12">12</div>
+          </div>
+          <div class="hxRow">
+            <div class="hxCol hxSpan-1">1</div>
+            <div class="hxCol hxSpan-11">11</div>
+          </div>
+          <div class="hxRow">
+            <div class="hxCol hxSpan-2">2</div>
+            <div class="hxCol hxSpan-10">10</div>
+          </div>
+          <div class="hxRow">
+            <div class="hxCol hxSpan-3">3</div>
+            <div class="hxCol hxSpan-9">9</div>
+          </div>
+          <div class="hxRow">
+            <div class="hxCol hxSpan-4">4</div>
+            <div class="hxCol hxSpan-8">8</div>
+          </div>
+          <div class="hxRow">
+            <div class="hxCol hxSpan-5">5</div>
+            <div class="hxCol hxSpan-7">7</div>
+          </div>
+          <div class="hxRow">
+            <div class="hxCol hxSpan-6">6</div>
+            <div class="hxCol hxSpan-6">6</div>
+          </div>
         </div>
       </div>
+
+      <footer>
+        {% code 'html' %}
+          <div class="hxRow">
+            <div class="hxCol hxSpan-12">12</div>
+          </div>
+          <div class="hxRow">
+            <div class="hxCol hxSpan-1">1</div>
+            <div class="hxCol hxSpan-11">11</div>
+          </div>
+          <div class="hxRow">
+            <div class="hxCol hxSpan-2">2</div>
+            <div class="hxCol hxSpan-10">10</div>
+          </div>
+          <div class="hxRow">
+            <div class="hxCol hxSpan-3">3</div>
+            <div class="hxCol hxSpan-9">9</div>
+          </div>
+          <div class="hxRow">
+            <div class="hxCol hxSpan-4">4</div>
+            <div class="hxCol hxSpan-8">8</div>
+          </div>
+          <div class="hxRow">
+            <div class="hxCol hxSpan-5">5</div>
+            <div class="hxCol hxSpan-7">7</div>
+          </div>
+          <div class="hxRow">
+            <div class="hxCol hxSpan-6">6</div>
+            <div class="hxCol hxSpan-6">6</div>
+          </div>
+        {% endcode %}
+      </footer>
     </div>
+  </section>
 
-    <footer>
-      {% code 'html' %}
-        <div class="hxRow">
-          <div class="hxCol hxSpan-12">12</div>
-        </div>
-        <div class="hxRow">
-          <div class="hxCol hxSpan-1">1</div>
-          <div class="hxCol hxSpan-11">11</div>
-        </div>
-        <div class="hxRow">
-          <div class="hxCol hxSpan-2">2</div>
-          <div class="hxCol hxSpan-10">10</div>
-        </div>
-        <div class="hxRow">
-          <div class="hxCol hxSpan-3">3</div>
-          <div class="hxCol hxSpan-9">9</div>
-        </div>
-        <div class="hxRow">
-          <div class="hxCol hxSpan-4">4</div>
-          <div class="hxCol hxSpan-8">8</div>
-        </div>
-        <div class="hxRow">
-          <div class="hxCol hxSpan-5">5</div>
-          <div class="hxCol hxSpan-7">7</div>
-        </div>
-        <div class="hxRow">
-          <div class="hxCol hxSpan-6">6</div>
-          <div class="hxCol hxSpan-6">6</div>
-        </div>
-      {% endcode %}
-    </footer>
-  </div>
-</section>
+  <section><!-- column offset -->
+    <header>
+      <h2 id="column-offset">Column Offset</h2>
+      <p>
+        You can use the <code>.hxOffset-{N}</code> class (1 &le; N &le; 11)
+        to offset your column from the start of the row.
+      </p>
+    </header>
 
-<section><!-- column offset -->
-  <h2 id="column-offset">Column Offset</h2>
-  <p>
-    You can use the <code>.hxOffset-{N}</code> class (1 &le; N &le; 11)
-    to offset your column from the start of the row.
-  </p>
-  <ul class="hxList">
-    <li>
-      <code>.hxOffset-{N}-{size}</code> responsive classes are available
-    </li>
-    <li>
-      <code>.hxOffset-{N}</code> is shorthand for <code>.hxOffset-{N}-xs</code>
-    </li>
-  </ul>
-  <div class="example">
-    <div class="grid-demo">
-      <div class="demo-container text-center">
-        <div class="hxRow">
-          <div class="hxCol hxSpan-2">2</div>
-          <div class="hxCol hxSpan-6 hxOffset-1">6</div>
-          <div class="hxCol hxSpan-2 hxOffset-1">2</div>
-        </div>
-        <div class="hxRow">
-          <div class="hxCol hxSpan-2 hxOffset-2">2</div>
-          <div class="hxCol hxSpan-4">4</div>
-          <div class="hxCol hxSpan-2">2</div>
-        </div>
-        <div class="hxRow">
-          <div class="hxCol hxSpan-4">4</div>
-          <div class="hxCol hxSpan-4 hxOffset-4">4</div>
+    <ul class="hxList">
+      <li>
+        <code>.hxOffset-{N}-{size}</code> responsive classes are available
+      </li>
+      <li>
+        <code>.hxOffset-{N}</code> is shorthand for <code>.hxOffset-{N}-xs</code>
+      </li>
+    </ul>
+
+    <div class="example">
+      <div class="grid-demo">
+        <div class="demo-container text-center">
+          <div class="hxRow">
+            <div class="hxCol hxSpan-2">2</div>
+            <div class="hxCol hxSpan-6 hxOffset-1">6</div>
+            <div class="hxCol hxSpan-2 hxOffset-1">2</div>
+          </div>
+          <div class="hxRow">
+            <div class="hxCol hxSpan-2 hxOffset-2">2</div>
+            <div class="hxCol hxSpan-4">4</div>
+            <div class="hxCol hxSpan-2">2</div>
+          </div>
+          <div class="hxRow">
+            <div class="hxCol hxSpan-4">4</div>
+            <div class="hxCol hxSpan-4 hxOffset-4">4</div>
+          </div>
         </div>
       </div>
+
+      <footer>
+        {% code 'html' %}
+          <div class="hxRow">
+            <div class="hxCol hxSpan-2">2</div>
+            <div class="hxCol hxSpan-6 hxOffset-1">6</div>
+            <div class="hxCol hxSpan-2 hxOffset-1">2</div>
+          </div>
+          <div class="hxRow">
+            <div class="hxCol hxSpan-2 hxOffset-2">2</div>
+            <div class="hxCol hxSpan-4">4</div>
+            <div class="hxCol hxSpan-2">2</div>
+          </div>
+          <div class="hxRow">
+            <div class="hxCol hxSpan-4">4</div>
+            <div class="hxCol hxSpan-4 hxOffset-4">4</div>
+          </div>
+        {% endcode %}
+      </footer>
     </div>
+  </section>
 
-    <footer>
-      {% code 'html' %}
-        <div class="hxRow">
-          <div class="hxCol hxSpan-2">2</div>
-          <div class="hxCol hxSpan-6 hxOffset-1">6</div>
-          <div class="hxCol hxSpan-2 hxOffset-1">2</div>
-        </div>
-        <div class="hxRow">
-          <div class="hxCol hxSpan-2 hxOffset-2">2</div>
-          <div class="hxCol hxSpan-4">4</div>
-          <div class="hxCol hxSpan-2">2</div>
-        </div>
-        <div class="hxRow">
-          <div class="hxCol hxSpan-4">4</div>
-          <div class="hxCol hxSpan-4 hxOffset-4">4</div>
-        </div>
-      {% endcode %}
-    </footer>
-  </div>
-</section>
+  <section><!-- column ordering -->
+    <header>
+      <h2 id="column-ordering">Column Ordering</h2>
+      <hx-alert type="info" status="fyi" persist>
+        Reordering columns does not change tab order.<br />
+        Tab order is based on the DOM order, not visual appearance.
+      </hx-alert>
+      <p>
+        Use the <code>.hxOrder-{N}</code> class (1 &le; N &le; 12) to reorder
+        your columns.
+      </p>
+    </header>
 
-<section><!-- column ordering -->
-  <h2 id="column-ordering">Column Ordering</h2>
-  <hx-alert type="info" status="fyi" persist>
-    Reordering columns does not change tab order.<br />
-    Tab order is based on the DOM order, not visual appearance.
-  </hx-alert>
-  <p>
-    Use the <code>.hxOrder-{N}</code> class (1 &le; N &le; 12) to reorder
-    your columns.
-  </p>
-  <ul class="hxList">
-    <li>
-      <code>.hxOrder-{N}-{size}</code> responsive classes are available
-    </li>
-    <li>
-      <code>.hxOrder-{N}</code> is shorthand for <code>.hxOrder-{N}-xs</code>
-    </li>
-  </ul>
-  <p>
-    The columns below are coded in HTML in the order of 2-4-1-3.<br />
-    The <code>.hxOrder-*</code> classes reordered them in the proper
-    numerical order.
-  </p>
-  <div class="example">
-    <div class="grid-demo">
-      <div class="demo-container text-center">
-        <div class="hxRow">
-          <div class="hxCol hxOrder-2">#2</div>
-          <div class="hxCol hxOrder-4">#4</div>
-          <div class="hxCol hxOrder-1">#1</div>
-          <div class="hxCol hxOrder-3">#3</div>
+    <ul class="hxList">
+      <li>
+        <code>.hxOrder-{N}-{size}</code> responsive classes are available
+      </li>
+      <li>
+        <code>.hxOrder-{N}</code> is shorthand for <code>.hxOrder-{N}-xs</code>
+      </li>
+    </ul>
+
+    <p>
+      The columns below are coded in HTML in the order of 2-4-1-3.<br />
+      The <code>.hxOrder-*</code> classes reordered them in the proper
+      numerical order.
+    </p>
+
+    <div class="example">
+      <div class="grid-demo">
+        <div class="demo-container text-center">
+          <div class="hxRow">
+            <div class="hxCol hxOrder-2">#2</div>
+            <div class="hxCol hxOrder-4">#4</div>
+            <div class="hxCol hxOrder-1">#1</div>
+            <div class="hxCol hxOrder-3">#3</div>
+          </div>
         </div>
       </div>
+
+      <footer>
+        {% code 'html' %}
+          <div class="hxRow">
+            <div class="hxCol hxOrder-2">#2</div>
+            <div class="hxCol hxOrder-4">#4</div>
+            <div class="hxCol hxOrder-1">#1</div>
+            <div class="hxCol hxOrder-3">#3</div>
+          </div>
+        {% endcode %}
+      </footer>
     </div>
+  </section>
 
-    <footer>
-      {% code 'html' %}
-        <div class="hxRow">
-          <div class="hxCol hxOrder-2">#2</div>
-          <div class="hxCol hxOrder-4">#4</div>
-          <div class="hxCol hxOrder-1">#1</div>
-          <div class="hxCol hxOrder-3">#3</div>
-        </div>
-      {% endcode %}
-    </footer>
-  </div>
-</section>
+  <section><!-- responsive options -->
+    <header>
+      <h2 id="responsive-options">Responsive Options</h2>
+      <p>
+        All column modifiers support adding an optional breakpoint.
+      </p>
+    </header>
 
-<section><!-- responsive options -->
-  <h2 id="responsive-options">Responsive Options</h2>
-  <ul class="hxList">
-    <li>All column modifiers support adding an optional breakpoint.</li>
-    <li>
-      Omitting the breakpoint will default to <code>xs</code>
-      (applies to all breakpoints).
-    </li>
-    <li>
-      Each respoinsive class corresponds to the <em>minimum</em> breakpoint
-      required to achieve the desired appearance.
-    </li>
-    <li>Larger breakpoints override smaller ones.</li>
-  </ul>
-  <table class="hxTable hxTable--condensed">
-    <thead>
-      <tr>
-        <th>CSS Class</th>
-        <th>Minimum Breakpoint</th>
-        <th>Overrides</th>
-        <th>Overridden By</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><code>.<i>hxModifier</i>-{N}[-<b>xs</b>]</code></td>
-        <td><code>0em (0px)</code></td>
-        <td>N/A</td>
-        <td>all below</td>
-      </tr>
-      <tr>
-        <td><code>.<i>hxModifier</i>-{N}-<b>sm</b></code></td>
-        <td><code>40em (~640px)</code></td>
-        <td>all above</td>
-        <td>all below</td>
-      </tr>
-      <tr>
-        <td><code>.<i>hxModifier</i>-{N}-<b>md</b></code></td>
-        <td><code>64em (~1024px)</code></td>
-        <td>all above</td>
-        <td>all below</td>
-      </tr>
-      <tr>
-        <td><code>.<i>hxModifier</i>-{N}-<b>lg</b></code></td>
-        <td><code>75em (~1200px)</code></td>
-        <td>all above</td>
-        <td>all below</td>
-      </tr>
-      <tr>
-        <td><code>.<i>hxModifier</i>-{N}-<b>xl</b></code></td>
-        <td><code>90em (~1440px)</code></td>
-        <td>all above</td>
-        <td>N/A</td>
-      </tr>
-    </tbody>
-  </table>
-  <div class="example">
-    <div class="grid-demo">
-      <div class="demo-container text-center">
-        <div id="querySize"></div>
-        <div class="hxRow">
-          <div class="demoCol hxCol hxSpan-12-xs hxSpan-4-sm hxSpan-3-md hxSpan-2-lg hxSpan-1-xl"></div>
-          <div class="demoCol hxCol hxSpan-6-xs hxSpan-4-sm hxSpan-6-md hxSpan-8-lg hxSpan-10-xl"></div>
-          <div class="demoCol hxCol hxSpan-6-xs hxSpan-4-sm hxSpan-3-md hxSpan-2-lg hxSpan-1-xl"></div>
-        </div>
-        <div class="hxRow">
-          <div class="demoCol hxCol hxSpan-12-xs hxSpan-4-sm hxSpan-3-md hxSpan-2-lg hxSpan-1-xl"></div>
-          <div class="demoCol hxCol hxSpan-12-xs hxSpan-8-sm hxSpan-9-md hxSpan-10-lg hxSpan-11-xl"></div>
-        </div>
-        <div class="hxRow">
-          <div class="demoCol hxCol hxSpan-12-xs hxSpan-8-sm hxSpan-6-md hxSpan-4-lg hxSpan-3-xl"></div>
-          <div class="demoCol hxCol hxSpan-12-xs hxSpan-4-sm hxSpan-6-md hxSpan-8-lg hxSpan-9-xl"></div>
+    <ul class="hxList">
+      <li>
+        Omitting the breakpoint will default to <code>xs</code>
+        (applies to all breakpoints).
+      </li>
+      <li>
+        Each respoinsive class corresponds to the <em>minimum</em> breakpoint
+        required to achieve the desired appearance.
+      </li>
+      <li>Larger breakpoints override smaller ones.</li>
+    </ul>
+
+    <table class="hxTable hxTable--condensed">
+      {# TODO: add table caption #}
+      <thead>
+        <tr>
+          <th>CSS Class</th>
+          <th>Minimum Breakpoint</th>
+          <th>Overrides</th>
+          <th>Overridden By</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>.<i>hxModifier</i>-{N}[-<b>xs</b>]</code></td>
+          <td><code>0em (0px)</code></td>
+          <td>N/A</td>
+          <td>all below</td>
+        </tr>
+        <tr>
+          <td><code>.<i>hxModifier</i>-{N}-<b>sm</b></code></td>
+          <td><code>40em (~640px)</code></td>
+          <td>all above</td>
+          <td>all below</td>
+        </tr>
+        <tr>
+          <td><code>.<i>hxModifier</i>-{N}-<b>md</b></code></td>
+          <td><code>64em (~1024px)</code></td>
+          <td>all above</td>
+          <td>all below</td>
+        </tr>
+        <tr>
+          <td><code>.<i>hxModifier</i>-{N}-<b>lg</b></code></td>
+          <td><code>75em (~1200px)</code></td>
+          <td>all above</td>
+          <td>all below</td>
+        </tr>
+        <tr>
+          <td><code>.<i>hxModifier</i>-{N}-<b>xl</b></code></td>
+          <td><code>90em (~1440px)</code></td>
+          <td>all above</td>
+          <td>N/A</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="example">
+      <div class="grid-demo">
+        <div class="demo-container text-center">
+          <div id="querySize"></div>
+          <div class="hxRow">
+            <div class="demoCol hxCol hxSpan-12-xs hxSpan-4-sm hxSpan-3-md hxSpan-2-lg hxSpan-1-xl"></div>
+            <div class="demoCol hxCol hxSpan-6-xs hxSpan-4-sm hxSpan-6-md hxSpan-8-lg hxSpan-10-xl"></div>
+            <div class="demoCol hxCol hxSpan-6-xs hxSpan-4-sm hxSpan-3-md hxSpan-2-lg hxSpan-1-xl"></div>
+          </div>
+          <div class="hxRow">
+            <div class="demoCol hxCol hxSpan-12-xs hxSpan-4-sm hxSpan-3-md hxSpan-2-lg hxSpan-1-xl"></div>
+            <div class="demoCol hxCol hxSpan-12-xs hxSpan-8-sm hxSpan-9-md hxSpan-10-lg hxSpan-11-xl"></div>
+          </div>
+          <div class="hxRow">
+            <div class="demoCol hxCol hxSpan-12-xs hxSpan-8-sm hxSpan-6-md hxSpan-4-lg hxSpan-3-xl"></div>
+            <div class="demoCol hxCol hxSpan-12-xs hxSpan-4-sm hxSpan-6-md hxSpan-8-lg hxSpan-9-xl"></div>
+          </div>
         </div>
       </div>
+
+      <footer>
+        {% code 'html' %}
+          <div class="hxRow">
+            <div class="demoCol hxCol hxSpan-12-xs hxSpan-4-sm hxSpan-3-md hxSpan-2-lg hxSpan-1-xl"></div>
+            <div class="demoCol hxCol hxSpan-6-xs hxSpan-4-sm hxSpan-6-md hxSpan-8-lg hxSpan-10-xl"></div>
+            <div class="demoCol hxCol hxSpan-6-xs hxSpan-4-sm hxSpan-3-md hxSpan-2-lg hxSpan-1-xl"></div>
+          </div>
+          <div class="hxRow">
+            <div class="demoCol hxCol hxSpan-12-xs hxSpan-4-sm hxSpan-3-md hxSpan-2-lg hxSpan-1-xl"></div>
+            <div class="demoCol hxCol hxSpan-12-xs hxSpan-8-sm hxSpan-9-md hxSpan-10-lg hxSpan-11-xl"></div>
+          </div>
+          <div class="hxRow">
+            <div class="demoCol hxCol hxSpan-12-xs hxSpan-8-sm hxSpan-6-md hxSpan-4-lg hxSpan-3-xl"></div>
+            <div class="demoCol hxCol hxSpan-12-xs hxSpan-4-sm hxSpan-6-md hxSpan-8-lg hxSpan-9-xl"></div>
+          </div>
+        {% endcode %}
+      </footer>
     </div>
+  </section>
 
-    <footer>
-      {% code 'html' %}
-        <div class="hxRow">
-          <div class="demoCol hxCol hxSpan-12-xs hxSpan-4-sm hxSpan-3-md hxSpan-2-lg hxSpan-1-xl"></div>
-          <div class="demoCol hxCol hxSpan-6-xs hxSpan-4-sm hxSpan-6-md hxSpan-8-lg hxSpan-10-xl"></div>
-          <div class="demoCol hxCol hxSpan-6-xs hxSpan-4-sm hxSpan-3-md hxSpan-2-lg hxSpan-1-xl"></div>
-        </div>
-        <div class="hxRow">
-          <div class="demoCol hxCol hxSpan-12-xs hxSpan-4-sm hxSpan-3-md hxSpan-2-lg hxSpan-1-xl"></div>
-          <div class="demoCol hxCol hxSpan-12-xs hxSpan-8-sm hxSpan-9-md hxSpan-10-lg hxSpan-11-xl"></div>
-        </div>
-        <div class="hxRow">
-          <div class="demoCol hxCol hxSpan-12-xs hxSpan-8-sm hxSpan-6-md hxSpan-4-lg hxSpan-3-xl"></div>
-          <div class="demoCol hxCol hxSpan-12-xs hxSpan-4-sm hxSpan-6-md hxSpan-8-lg hxSpan-9-xl"></div>
-        </div>
-      {% endcode %}
-    </footer>
-  </div>
-</section>
+  <section><!-- column wrapping -->
+    <header>
+      <h2 id="column-wrapping">Column Wrapping</h2>
+      <p>
+        Columns wrap if a row's total column count exceeds 12.
+      </p>
+    </header>
 
-<section><!-- column wrapping -->
-  <h2 id="column-wrapping">Column Wrapping</h2>
-  <hx-alert type="info" status="note" persist>
-    Columns wrap if the total column width count within the row exceeds 12.
-  </hx-alert>
-  <p>
-    The following example should arrange the content into:
-  </p>
-  <ul class="hxList">
-    <li>3 columns on small screens</li>
-    <li>4 columns on medium screens</li>
-    <li>6 columns on all other sizes</li>
-  </ul>
-  <div class="example">
-    <div class="grid-demo">
-      <div class="demo-container text-center">
-        <div class="hxRow">
-          <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Snow White</div>
-          <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">The Evil Queen</div>
-          <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">The Prince</div>
-          <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Happy</div>
-          <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Sleepy</div>
-          <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Sneezy</div>
-          <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Grumpy</div>
-          <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Bashful</div>
-          <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Dopey</div>
-          <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Doc</div>
+    <p>
+      The following example should arrange the content into:
+    </p>
+
+    <ul class="hxList">
+      <li>3 columns on small screens</li>
+      <li>4 columns on medium screens</li>
+      <li>6 columns on all other sizes</li>
+    </ul>
+
+    <div class="example">
+      <div class="grid-demo">
+        <div class="demo-container text-center">
+          <div class="hxRow">
+            <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Snow White</div>
+            <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">The Evil Queen</div>
+            <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">The Prince</div>
+            <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Happy</div>
+            <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Sleepy</div>
+            <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Sneezy</div>
+            <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Grumpy</div>
+            <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Bashful</div>
+            <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Dopey</div>
+            <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Doc</div>
+          </div>
         </div>
       </div>
+
+      <footer>
+        {% code 'html' %}
+          <div class="hxRow">
+            <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Snow White</div>
+            <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">The Evil Queen</div>
+            <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">The Prince</div>
+            <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Happy</div>
+            <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Sleepy</div>
+            <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Sneezy</div>
+            <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Grumpy</div>
+            <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Bashful</div>
+            <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Dopey</div>
+            <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Doc</div>
+          </div>
+        {% endcode %}
+      </footer>
     </div>
+  </section>
 
-    <footer>
-      {% code 'html' %}
-        <div class="hxRow">
-          <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Snow White</div>
-          <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">The Evil Queen</div>
-          <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">The Prince</div>
-          <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Happy</div>
-          <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Sleepy</div>
-          <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Sneezy</div>
-          <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Grumpy</div>
-          <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Bashful</div>
-          <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Dopey</div>
-          <div class="hxCol hxSpan-4-xs hxSpan-3-md hxSpan-2-lg">Doc</div>
-        </div>
-      {% endcode %}
-    </footer>
-  </div>
-</section>
+  <section><!-- nesting containers -->
+    <header>
+      <h2 id="nesting-containers">Nesting Containers</h2>
+      <hx-alert type="warning" status="warning" persist>
+        Do not apply row and column container classes to the same element.
+      </hx-alert>
+      <p>Rows and columns can be nested as deep as needed.</p>
+    </header>
 
-<section><!-- nesting containers -->
-  <h2 id="nesting-containers">Nesting Containers</h2>
-  <hx-alert type="warning" status="warning" persist>
-    Do not apply row and column container classes to the same element.
-  </hx-alert>
-  <p>You can nest rows and columns as deep as necessary.</p>
-  <div class="example">
-    <div class="grid-demo">
-      <div class="demo-container text-center">
-        <div class="hxRow">
-          <div class="hxCol hxSpan-12">12
-            <div class="hxRow">
-              <div class="hxCol hxSpan-6">6
-                <div class="hxRow">
-                  <div class="hxCol hxSpan-4">4</div>
-                  <div class="hxCol hxSpan-4">4</div>
-                  <div class="hxCol hxSpan-4">4</div>
+    <div class="example">
+      <div class="grid-demo">
+        <div class="demo-container text-center">
+          <div class="hxRow">
+            <div class="hxCol hxSpan-12">12
+              <div class="hxRow">
+                <div class="hxCol hxSpan-6">6
+                  <div class="hxRow">
+                    <div class="hxCol hxSpan-4">4</div>
+                    <div class="hxCol hxSpan-4">4</div>
+                    <div class="hxCol hxSpan-4">4</div>
+                  </div>
                 </div>
-              </div>
-              <div class="hxCol hxSpan-6">6
-                <div class="hxRow">
-                  <div class="hxCol hxSpan-3">3</div>
-                  <div class="hxCol hxSpan-9">9</div>
+                <div class="hxCol hxSpan-6">6
+                  <div class="hxRow">
+                    <div class="hxCol hxSpan-3">3</div>
+                    <div class="hxCol hxSpan-9">9</div>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
 
-    <footer>
-      {% code 'html' %}
-        <div class="hxRow">
-          <div class="hxCol hxSpan-12">12
-            <div class="hxRow">
-              <div class="hxCol hxSpan-6">6
-                <div class="hxRow">
-                  <div class="hxCol hxSpan-4">4</div>
-                  <div class="hxCol hxSpan-4">4</div>
-                  <div class="hxCol hxSpan-4">4</div>
+      <footer>
+        {% code 'html' %}
+          <div class="hxRow">
+            <div class="hxCol hxSpan-12">12
+              <div class="hxRow">
+                <div class="hxCol hxSpan-6">6
+                  <div class="hxRow">
+                    <div class="hxCol hxSpan-4">4</div>
+                    <div class="hxCol hxSpan-4">4</div>
+                    <div class="hxCol hxSpan-4">4</div>
+                  </div>
                 </div>
-              </div>
-              <div class="hxCol hxSpan-6">6
-                <div class="hxRow">
-                  <div class="hxCol hxSpan-3">3</div>
-                  <div class="hxCol hxSpan-9">9</div>
+                <div class="hxCol hxSpan-6">6
+                  <div class="hxRow">
+                    <div class="hxCol hxSpan-3">3</div>
+                    <div class="hxCol hxSpan-9">9</div>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
-      {% endcode %}
-    </footer>
-  </div>
-</section>
-
-<section><!-- styling containers -->
-  <h2 id="styling-containers">Styling Containers</h2>
-  <hx-alert type="warning" status="warning" persist>
-    Do not attempt to style rows or columns directly.
-  </hx-alert>
-  <ul class="hxList">
-    <li>Rows have margins set to align the outer columns with surrounding content.</li>
-    <li>Columns in a row have padding applied to them to simulate gutters.</li>
-    <li>Wrap your content in a <code>&lt;div&gt;</code> to apply custom CSS.</li>
-  </ul>
-  <div class="example">
-    <div class="grid-demo">
-      <div class="hxRow">
-        <div class="hxCol hxSpan-4">
-          <p>
-            As a user, I should be able to measure the flexible project
-            management so that I can decide the alpha VOC relationships
-            outside the big interactions. If we adjust upon the relationships,
-            we can get the pair meeting outside the WIP commitment.
-          </p>
-        </div>
-        <div class="hxCol hxSpan-4">
-          <div class="example-styled-container">
-            <p>
-              This is a custom styled container! Notice how it fills the
-              green areas of the column.
-            </p>
-          </div>
-        </div>
-        <div class="hxCol hxSpan-4">
-          <p>
-            As a user, I should be able to measure the flexible project
-            management so that I can decide the alpha VOC relationships
-            outside the big interactions. If we adjust upon the relationships,
-            we can get the pair meeting outside the WIP commitment.
-          </p>
-        </div>
-      </div>
+        {% endcode %}
+      </footer>
     </div>
+  </section>
 
-    <footer>
-      {% code 'html' %}
+  <section><!-- styling containers -->
+    <header>
+      <h2 id="styling-containers">Styling Containers</h2>
+      <hx-alert type="warning" status="warning" persist>
+        Do not attempt to style rows or columns directly.
+      </hx-alert>
+      <p>
+        There are limitations to styling rows and columns.
+      </p>
+    </header>
+
+    <ul class="hxList">
+      <li>Rows have margins set to align the outer columns with surrounding content.</li>
+      <li>Columns in a row have padding applied to them to simulate gutters.</li>
+      <li>Wrap your content in a <code>&lt;div&gt;</code> to apply custom CSS.</li>
+    </ul>
+
+    <div class="example">
+      <div class="grid-demo">
         <div class="hxRow">
           <div class="hxCol hxSpan-4">
-            <p>...</p>
+            <p>
+              As a user, I should be able to measure the flexible project
+              management so that I can decide the alpha VOC relationships
+              outside the big interactions. If we adjust upon the relationships,
+              we can get the pair meeting outside the WIP commitment.
+            </p>
           </div>
           <div class="hxCol hxSpan-4">
             <div class="example-styled-container">
@@ -550,56 +567,94 @@ also:
             </div>
           </div>
           <div class="hxCol hxSpan-4">
-            <p>...</p>
+            <p>
+              As a user, I should be able to measure the flexible project
+              management so that I can decide the alpha VOC relationships
+              outside the big interactions. If we adjust upon the relationships,
+              we can get the pair meeting outside the WIP commitment.
+            </p>
           </div>
-        </div>
-      {% endcode %}
-    </footer>
-  </div>
-</section>
-
-<section><!-- going gutterless -->
-  <h2 id="going-gutterless">Going Gutterless</h2>
-  <ul class="hxList">
-    <li>
-      Add the <code>.hxGutterless</code> CSS class to your row container
-      to remove gutters from its immediate children.
-    </li>
-  </ul>
-  <p class="hxSubBody hxSubdued">
-    <hx-icon type="info-circle"></hx-icon>
-    Notice how the nested row in the second column still applies its gutters.
-  </p>
-  <div class="example">
-    <div class="grid-demo">
-      <div class="demo-container text-center">
-        <div class="hxRow hxGutterless">
-          <div class="hxCol">1/3</div>
-          <div class="hxCol">1/3
-            <div class="hxRow">
-              <div class="hxCol">1/2</div>
-              <div class="hxCol">1/2</div>
-            </div>
-          </div>
-          <div class="hxCol">1/3</div>
         </div>
       </div>
-    </div>
 
-    <footer>
-      {% code 'html' %}
-        <div class="hxRow hxGutterless">
-          <div class="hxCol">1/3</div>
-          <div class="hxCol">1/3
-            <div class="hxRow">
-              <div class="hxCol">1/2</div>
-              <div class="hxCol">1/2</div>
+      <footer>
+        {% code 'html' %}
+          <div class="hxRow">
+            <div class="hxCol hxSpan-4">
+              <p>...</p>
+            </div>
+            <div class="hxCol hxSpan-4">
+              <div class="example-styled-container">
+                <p>
+                  This is a custom styled container! Notice how it fills the
+                  green areas of the column.
+                </p>
+              </div>
+            </div>
+            <div class="hxCol hxSpan-4">
+              <p>...</p>
             </div>
           </div>
-          <div class="hxCol">1/3</div>
+        {% endcode %}
+      </footer>
+    </div>
+  </section>
+
+  <section><!-- going gutterless -->
+    <header>
+      <h2 id="going-gutterless">Going Gutterless</h2>
+      <p>
+        Add the <code>.hxGutterless</code> CSS class to your row container
+        to remove gutters from its immediate children.
+      </p>
+    </header>
+
+    <p class="hxSubBody hxSubdued">
+      <hx-icon type="info-circle"></hx-icon>
+      Notice how the nested row in the second column still applies its gutters.
+    </p>
+
+    <div class="example">
+      <div class="grid-demo">
+        <div class="demo-container text-center">
+          <div class="hxRow hxGutterless">
+            <div class="hxCol">1/3</div>
+            <div class="hxCol">1/3
+              <div class="hxRow">
+                <div class="hxCol">1/2</div>
+                <div class="hxCol">1/2</div>
+              </div>
+            </div>
+            <div class="hxCol">1/3</div>
+          </div>
         </div>
-      {% endcode %}
-    </footer>
-  </div>
-</section>
+      </div>
+
+      <footer>
+        {% code 'html' %}
+          <div class="hxRow hxGutterless">
+            <div class="hxCol">1/3</div>
+            <div class="hxCol">1/3
+              <div class="hxRow">
+                <div class="hxCol">1/2</div>
+                <div class="hxCol">1/2</div>
+              </div>
+            </div>
+            <div class="hxCol">1/3</div>
+          </div>
+        {% endcode %}
+      </footer>
+    </div>
+  </section>
+
+  <section><!-- compatibility -->
+    <header>
+      <h2 id="compatibility">Compatibility</h2>
+      {# TODO: add section description #}
+    </header>
+
+    <ul class="hxList">
+      <li>HelixUI Grid is not compatible with Bootstrap grid styles.</li>
+    </ul>
+  </section>
 {% endblock %}

--- a/docs/components/icons/index.html
+++ b/docs/components/icons/index.html
@@ -6,12 +6,20 @@ also:
   elements/hx-file-icon: <hx-file-icon>
 ---
 {% extends 'component.njk' %}
+
+{% block page_header %}
+  {# TODO: add component description #}
+{% endblock %}
+
 {% block content %}
   <section>
-    <h2 id="basic-icon">Basic Icon</h2>
-    <p>
-      Use the <code>&lt;hx-icon&gt;</code> element to render a styleable inline SVG icon.
-    </p>
+    <header>
+      <h2 id="basic-icon">Basic Icon</h2>
+      <p>
+        Use the <code>&lt;hx-icon&gt;</code> element to render a styleable inline SVG icon.
+      </p>
+    </header>
+
     <div class="example">
       <div>
         <hx-icon type="bell"></hx-icon>
@@ -26,25 +34,39 @@ also:
   </section>
 
   <section>
-    <h2 id="file-icons">File Icon</h2>
-    <p class="hxSubBody">Added: v0.9.0</p>
-    <p>
-      Create a styled "file" with optional icon and extension.
-    </p>
+    <header>
+      <h2 id="file-icons">File Icon</h2>
+      <p class="hxSubBody">Added: v0.9.0</p>
+      <p>
+        Create a styled "file" with optional icon and extension.
+      </p>
+    </header>
+
     <div class="example" id="vue-fileIconDemo" v-cloak>
       <header>
         <form class="beta-hxForm">
-          <div>
-            <label for="selType" class="beta-hxFieldName">Type</label>
+          <hx-select-control>
             <select id="selType" v-model="type">
-              <option v-for="_type in types" :value="_type" v-text="_type">
+              <option v-for="_type in types" :value="_type">
+                {% raw %}{{_type}}{% endraw %}
               </option>
             </select>
-          </div>
-          <p>
-            <label for="txtExt" class="beta-hxFieldName">File Extension</label>
-            <input id="txtExt" class="hxTextCtrl" v-model="ext" />
-          </p>
+            <hx-select></hx-select>
+            <label for="selType">
+              Type
+            </label>
+          </hx-select-control>
+
+          <hx-text-control>
+            <input
+              id="txtExt"
+              type="text"
+              v-model="ext"
+            />
+            <label for="txtExt">
+              File Extension
+            </label>
+          </hx-text-control>
         </form>
       </header>
 
@@ -68,13 +90,17 @@ also:
   </section>
 
   <section>
-    <h2 id="available-icons">Available Icons</h2>
-    <p>
-      <a href="downloads/helix-ui-{{VERSION}}-icons.tgz">
-        <hx-icon type="download"></hx-icon>
-        Download All Icons (SVG)
-      </a>
-    </p>
+    <header>
+      <h2 id="available-icons">Available Icons</h2>
+      <p>
+        <a href="downloads/helix-ui-{{VERSION}}-icons.tgz">
+          <hx-icon type="download"></hx-icon>
+          Download All Icons (SVG)
+        </a>
+      </p>
+      {# TODO: add section description #}
+    </header>
+
     <div id="vue-availableIcons" v-cloak>
       <div class="hxRow">
         <div class="hxCol hxSpan-12-xs hxSpan-6-md hxSpan-4-xl">

--- a/docs/components/layouts/index.html
+++ b/docs/components/layouts/index.html
@@ -8,28 +8,32 @@ also:
   components/navigation: Navigation
 ---
 {% extends 'component.njk' %}
+
+{% block page_header %}
+  <p>
+    The Layouts component provides information about Helix application anatomy
+    for the purposes of advanced customization.
+  </p>
+{% endblock %}
+
 {% block content %}
   <section>
-    <p class="comfortable">
-      The Layouts component provides information about Helix application anatomy
-      for the purposes of advanced customization.
+    <header>
+      <h2 id="layout-templates">Layout Templates</h2>
+      {# TODO: add section description #}
+    </header>
+
+    <p>
+      It is highly recommended that you use one of the pre-defined layout
+      templates described below.
     </p>
-    <p class="comfortable">
-      It is highly recommended that you use one of the pre-defined layout templates
-      mentioned in <a href="#layout-templates">Layout Templates</a> below.
-    </p>
-    <p class="comfortable">
-      If you find that the pre-defined templates don't meet your needs,
-      please skip ahead to <a href="#prerequisites">Prerequisites</a> to review
+
+    <p>
+      If you find that the pre-defined templates do not meet your needs, please
+      skip ahead to <a href="#prerequisites">Prerequisites</a> to review
       documentation needed to better understand how to customize your application.
     </p>
-  </section>
 
-  <section>
-    <h2 id="layout-templates">Layout Templates</h2>
-    <p>
-      Download or preview one of the pre-defined layout templates below.
-    </p>
     <p class="hxSubBody hxSubdued">
       <hx-icon type="info-circle"></hx-icon>
       All layout templates are optimized for use in single-page applications (SPAs).
@@ -102,11 +106,16 @@ also:
   </section>
 
   <section>
-    <h2 id="prerequisites">Prerequisites</h2>
-    <p class="comfortable">
+    <header>
+      <h2 id="prerequisites">Prerequisites</h2>
+      {# TODO: add section description #}
+    </header>
+
+    <p>
       To get the most out of this documentation, developers are
       expected to:
     </p>
+
     <ol class="hxList">
       <li>
         Review the instructions in the
@@ -125,11 +134,14 @@ also:
   </section>
 
   <section>
-    <h2 id="layout-anatomy">Layout Anatomy</h2>
-    <p class="comfortable">
-      Layouts are composed of several different areas. Understanding the purpose
-      for each area should help you locate the best place to add custom containers.
-    </p>
+    <header>
+      <h2 id="layout-anatomy">Layout Anatomy</h2>
+      <p>
+        Layouts are composed of several different areas. Understanding the purpose
+        for each area should help you locate the best place to add custom containers.
+      </p>
+    </header>
+
     <dl class="hxList">
       <div>
         <dt>
@@ -233,15 +245,19 @@ also:
   </section>
 
   <section><!-- Body -->
-    <h2 id="document-body">Document Body</h2>
-    <p>
-      The document <code>&lt;body&gt;</code> is the root element
-      for applying CSS needed for any application layout.
-    </p>
+    <header>
+      <h2 id="document-body">Document Body</h2>
+      <p>
+        The document <code>&lt;body&gt;</code> is the root element
+        for applying CSS needed for any application layout.
+      </p>
+    </header>
+
     <p>
       Add one of the following CSS classes to the <code>&lt;body&gt;</code> element
       to begin with pre-defined layout styles.
     </p>
+
     <ul class="hxList">
       <li><code>hxVertical</code> for a vertical layout</li>
       <li><code>hxHorizontal</code> for a horizontal layout</li>
@@ -249,15 +265,19 @@ also:
   </section>
 
   <section><!-- App Container -->
-    <h2 id="app-container">App Container</h2>
-    <p>
-      The app container serves as the mounting point
-      for your single-page application.
-    </p>
+    <header>
+      <h2 id="app-container">App Container</h2>
+      <p>
+        The app container serves as the mounting point
+        for your single-page application.
+      </p>
+    </header>
+
     <ul class="hxList">
       <li>It must have an ID of <code>app</code>.</li>
       <li>It can be any block element.</li>
     </ul>
+
     <hx-tabset class="beta-hxBound">
       <hx-tablist>
         <hx-tab>HTML</hx-tab>
@@ -289,20 +309,28 @@ also:
   </section>
 
   <section><!-- Stage -->
-    <h2 id="stage-area">Stage</h2>
-    <p class="comfortable">
-      The stage serves as the root element required by client-side frameworks
-      that use virtual DOM technologies (i.e., hyperscript). It can be divided
-      into three areas:
+    <header>
+      <h2 id="stage-area">Stage</h2>
+      <p>
+        The stage serves as the root element required by client-side frameworks
+        that use virtual DOM technologies (e.g., hyperscript).
+      </p>
+    </header>
+
+    <p>
+      The Stage can be divided into three areas:
     </p>
+
     <ol class="hxList">
       <li><a href="#nav-area">Nav</a> (optional)</li>
       <li><a href="#main-content">Main Content</a></li>
       <li>left or right <a href="#side-rail">Side Rail</a> (optional)</li>
     </ol>
+
     <p>
       The stage container must have an ID of <code>stage</code>.
     </p>
+
     <figure class="hxFigure">
       {% code 'html' %}
         <div id="stage">
@@ -331,10 +359,13 @@ also:
   </section>
 
   <section><!-- Nav -->
-    <h2 id="nav-area">Nav</h2>
-    <p>
-      The nav area houses hyperlinks to pages within your application.
-    </p>
+    <header>
+      <h2 id="nav-area">Nav</h2>
+      <p>
+        The nav area houses hyperlinks to pages within your application.
+      </p>
+    </header>
+
     <ul class="hxList">
       <li>
         It must have an ID of <code>nav</code>.
@@ -348,6 +379,7 @@ also:
         for content information.
       </li>
     </ul>
+
     <figure class="hxFigure">
       {% code 'html' %}
         <nav id="nav">
@@ -359,10 +391,13 @@ also:
   </section>
 
   <section><!-- Main Content -->
-    <h2 id="main-content">Main Content</h2>
-    <p>
-      The main content area houses primary page content.
-    </p>
+    <header>
+      <h2 id="main-content">Main Content</h2>
+      <p>
+        The main content area houses primary page content.
+      </p>
+    </header>
+
     <ul class="hxList">
       <li>
         It must have an ID of <code>content</code>.
@@ -376,16 +411,19 @@ also:
         legacy support for accessible user agents.
       </li>
     </ul>
+
     <p class="hxSubdued hxSubBody">
       <hx-icon type="info-circle"></hx-icon>
       The main content area behaves like a non-wrapping grid row
       when used in a horizontal layout.
     </p>
+
     <p class="hxSubdued hxSubBody">
       <hx-icon type="info-circle"></hx-icon>
       Padding must be applied manually, using <a href="components/box">Box</a>
       component styles.
     </p>
+
     <figure class="hxFigure">
       {% code 'html' %}
         <main role="main" id="content">
@@ -397,10 +435,13 @@ also:
   </section>
 
   <section><!-- Side Rail -->
-    <h2 id="side-rail">Side Rail</h2>
-    <p>
-      The side rail houses secondary page content.
-    </p>
+    <header>
+      <h2 id="side-rail">Side Rail</h2>
+      <p>
+        The side rail houses secondary page content.
+      </p>
+    </header>
+
     <ul class="hxList">
       <li>
         Use an <code>&lt;aside&gt;</code> element to provide the best support
@@ -410,14 +451,17 @@ also:
         Add the <code>hxSiderail</code> CSS class to apply visual styling.
       </li>
     </ul>
+
     <p class="hxSubdued hxSubBody">
       <hx-icon type="exclamation-triangle"></hx-icon>
       Avoid using a side rail in a horizontal layout.
     </p>
+
     <p class="hxSubdued hxSubBody">
       <hx-icon type="exclamation-triangle"></hx-icon>
       Avoid adding multiple side rails on a single page.
     </p>
+
     <figure class="hxFigure">
       {% code 'html' %}
         <aside class="hxSiderail">

--- a/docs/components/lists/index.html
+++ b/docs/components/lists/index.html
@@ -3,19 +3,35 @@ title: Lists
 minver: 0.2.0
 ---
 {% extends 'component.njk' %}
+
+{% block page_header %}
+  {# TODO: add component description #}
+{% endblock %}
+
 {% block content %}
   <section>
-    <h2 id="description-list">Description List</h2>
-    <p class="hxSubBody">Added: v0.2.0</p>
+    <header>
+      <h2 id="description-list">Description List</h2>
+      <p class="hxSubBody">Added: v0.2.0</p>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example" id="vue-listDemo" v-cloak>
       <header>
         <form class="beta-hxForm">
           <fieldset>
             <legend class="beta-hxFieldName">Options</legend>
-            <div>
-              <input id="chkIsVertical" type="checkbox" v-model="isVertical" />
-              <label for="chkIsVertical">Vertical Layout</label>
-            </div>
+            <hx-checkbox-control>
+              <input
+                id="chkIsVertical"
+                type="checkbox"
+                v-model="isVertical"
+              />
+              <label for="chkIsVertical">
+                <hx-checkbox></hx-checkbox>
+                Vertical Layout
+              </label>
+            </hx-checkbox-control>
           </fieldset>
         </form>
       </header>
@@ -70,8 +86,12 @@ minver: 0.2.0
   </section>
 
   <section>
-    <h2 id="unordered-list">Unordered List</h2>
-    <p class="hxSubBody">Added: v0.10.0</p>
+    <header>
+      <h2 id="unordered-list">Unordered List</h2>
+      <p class="hxSubBody">Added: v0.10.0</p>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example">
       <div>
         <ul class="hxList">
@@ -110,8 +130,12 @@ minver: 0.2.0
   </section>
 
   <section>
-    <h2 id="ordered-list">Ordered List</h2>
-    <p class="hxSubBody">Added: v0.10.0</p>
+    <header>
+      <h2 id="ordered-list">Ordered List</h2>
+      <p class="hxSubBody">Added: v0.10.0</p>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example">
       <div>
         <ol class="hxList">

--- a/docs/components/loaders/index.html
+++ b/docs/components/loaders/index.html
@@ -6,19 +6,31 @@ also:
   elements/hx-progress: <hx-progress>
 ---
 {% extends 'component.njk' %}
+
 {% block content %}
   <section>
-    <h2 id="busy">Busy</h2>
-    <p class="hxSubBody">Added: v0.4.0</p>
+    <header>
+      <h2 id="busy">Busy</h2>
+      <p class="hxSubBody">Added: v0.4.0</p>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example" id="vue-busyDemo" v-cloak>
       <header>
         <form class="beta-hxForm">
           <fieldset>
             <legend class="beta-hxFieldName">Options</legend>
-            <div>
-              <input id="chkIsPaused" type="checkbox" v-model="isPaused" />
-              <label for="chkIsPaused">Paused</label>
-            </div>
+            <hx-checkbox-control>
+              <input
+                id="chkIsPaused"
+                type="checkbox"
+                v-model="isPaused"
+              />
+              <label for="chkIsPaused">
+                <hx-checkbox></hx-checkbox>
+                Paused
+              </label>
+            </hx-checkbox-control>
           </fieldset>
         </form>
       </header>
@@ -61,8 +73,12 @@ also:
   </section>
 
   <section>
-    <h2 id="progress-bar">Progress Bar</h2>
-    <p class="hxSubBody">Added: v0.7.0</p>
+    <header>
+      <h2 id="progress-bar">Progress Bar</h2>
+      <p class="hxSubBody">Added: v0.7.0</p>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example" id="vue-progressDemo" v-cloak>
       <header>
         <form class="beta-hxForm">

--- a/docs/components/menus/index.html
+++ b/docs/components/menus/index.html
@@ -8,9 +8,18 @@ also:
   elements/hx-menuitem: <hx-menuitem>
 ---
 {% extends 'component.njk' %}
+
+{% block page_header %}
+  {# TODO: add component description #}
+{% endblock %}
+
 {% block content %}
   <section>
-    <h2 id="basic-menu">Basic Menu</h2>
+    <header>
+      <h2 id="basic-menu">Basic Menu</h2>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example">
       <div>
         <hx-disclosure class="hxBtn" aria-controls="basicMenuId">
@@ -43,7 +52,11 @@ also:
   </section>
 
   <section>
-    <h2 id="cog-menu">Cog Menu</h2>
+    <header>
+      <h2 id="cog-menu">Cog Menu</h2>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example">
       <div>
         <hx-disclosure class="hxBtn hxCog" aria-controls="cogMenuId">
@@ -72,7 +85,11 @@ also:
   </section>
 
   <section>
-    <h2 id="grouped-menu">Grouped Menu</h2>
+    <header>
+      <h2 id="grouped-menu">Grouped Menu</h2>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example">
       <div>
         <hx-disclosure class="hxBtn" aria-controls="groupedMenuId">
@@ -123,7 +140,11 @@ also:
   </section>
 
   <section>
-    <h2 id="split-menu">Split Menu</h2>
+    <header>
+      <h2 id="split-menu">Split Menu</h2>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example">
       <div>
         <div class="hxBtnGroup hxPrimary" id="split-group">

--- a/docs/components/modals/index.html
+++ b/docs/components/modals/index.html
@@ -11,15 +11,23 @@ also:
 {% import '_utils.njk' as utils %}
 {% extends 'component.njk' %}
 
+{% block page_header %}
+  {# TODO: add component description #}
+{% endblock %}
+
 {% block content %}
   <section>
-    <h2 id="basic-modal">Basic Modal</h2>
+    <header>
+      <h2 id="basic-modal">Basic Modal</h2>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example" id="vue-basicModalDemo" v-cloak>
       <header>
         <form class="beta-hxForm">
           <fieldset>
             <legend class="beta-hxFieldName">Size</legend>
-            <div v-for="(_size, idx) in sizes">
+            <hx-radio-control v-for="(_size, idx) in sizes">
               <input
                 :id="'radSize' + idx"
                 :value="_size"
@@ -28,17 +36,26 @@ also:
                 v-model="size"
               />
               <label :for="'radSize' + idx">
-                <span v-text="_size.label"></span>
-                <em class="hxSubBody" v-if="_size.default">(default)</em>
+                <hx-radio></hx-radio>
+                {% raw %}{{_size.label}}{% endraw %}
               </label>
-            </div>
+              <p v-if="_size.default">(default)</p>
+            </hx-radio-control>
           </fieldset>
+
           <fieldset>
             <legend class="beta-hxFieldName">Options</legend>
-            <div>
-              <input id="chkIsScrollable" type="checkbox" v-model="isScrollable">
-              <label for="chkIsScrollable">Scroll Body</label>
-            </div>
+            <hx-checkbox-control>
+              <input
+                id="chkIsScrollable"
+                type="checkbox"
+                v-model="isScrollable"
+              />
+              <label for="chkIsScrollable">
+                <hx-checkbox></hx-checkbox>
+                Scroll Body
+              </label>
+            </hx-checkbox-control>
           </fieldset>
         </form>
       </header>
@@ -66,7 +83,7 @@ also:
               with content behind this modal cannot take
               place until this modal is closed.
             </p>
-            {{ utils.lorem(8) }}
+            {{utils.lorem(8)}}
           </hx-div>
 
           <hx-div v-else>
@@ -92,11 +109,14 @@ also:
       <hx-busy></hx-busy>
       <p>Loading...</p>
     </div>
-    <p class="hxSubdued hxSubBody">
-      <hx-icon type="info-circle"></hx-icon>
-      Please refer to
-      <a href="components/box/#scrolling-containers">"Scrolling Containers"</a>
-      documentation for more information about scrolling modal content.
-    </p>
+
+    <footer>
+      <p class="hxSubdued hxSubBody">
+        <hx-icon type="info-circle"></hx-icon>
+        Please refer to
+        <a href="components/box/#scrolling-containers">"Scrolling Containers"</a>
+        documentation for more information about scrolling modal content.
+      </p>
+    </footer>
   </section>
 {% endblock %}

--- a/docs/components/navigation/index.html
+++ b/docs/components/navigation/index.html
@@ -5,9 +5,18 @@ also:
   components/layouts: Layouts
 ---
 {% extends 'component.njk' %}
+
+{% block page_header %}
+  {# TODO: add component description #}
+{% endblock %}
+
 {% block content %}
   <section>
-    <h2 id="vertical-navigation">Vertical Navigation</h2>
+    <header>
+      <h2 id="vertical-navigation">Vertical Navigation</h2>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example">
       <div class="nav-demo">
         <nav class="hxNav">

--- a/docs/components/pagination/index.html
+++ b/docs/components/pagination/index.html
@@ -6,15 +6,18 @@ also:
   components/icons: Icons
 ---
 {% extends 'component.njk' %}
+
+{% block page_header %}
+  {# TODO: add component description #}
+{% endblock %}
+
 {% block content %}
   <section>
-    <p>
-      The <code>aria-current</code> attribute needs to be added in order to apply style as well as denote semantic meaning.
-    </p>
-  </section>
+    <header>
+      <h2 id="first-page">First Page</h2>
+      {# TODO: add section description #}
+    </header>
 
-  <section>
-    <h2 id="first-page">First Page</h2>
     <div class="example">
       <div>
         <div class="hxPagination hxBtnGroup">
@@ -65,7 +68,11 @@ also:
   </section>
 
   <section>
-    <h2 id="middle-page">Middle Page</h2>
+    <header>
+      <h2 id="middle-page">Middle Page</h2>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example">
       <div>
         <div class="hxPagination hxBtnGroup">
@@ -116,7 +123,11 @@ also:
   </section>
 
   <section>
-    <h2 id="last-page">Last Page</h2>
+    <header>
+      <h2 id="last-page">Last Page</h2>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example">
       <div>
         <div class="hxPagination hxBtnGroup">
@@ -164,6 +175,18 @@ also:
         {% endcode %}
       </footer>
     </div>
+  </section>
+
+  <section>
+    <header>
+      <h2 id="accessibility">Accessibility</h2>
+      {# TODO: add section description #}
+    </header>
+
+    <p>
+      The <code>aria-current</code> attribute needs to be added to the current
+      button in order to apply style as well as denote semantic meaning.
+    </p>
   </section>
 {% endblock %}
 

--- a/docs/components/panels/index.html
+++ b/docs/components/panels/index.html
@@ -158,7 +158,7 @@ also:
 
               <hx-tabpanel>
                 <p>Scrolling Tab Panel</p>
-                {{ utils.lorem(5) }}
+                {{utils.lorem(5)}}
               </hx-tabpanel>
             </hx-tabcontent>
           </hx-tabset>

--- a/docs/components/pills/index.html
+++ b/docs/components/pills/index.html
@@ -7,27 +7,46 @@ also:
   elements/hx-status: <hx-status>
 ---
 {% extends 'component.njk' %}
+
+{% block page_header %}
+  {# TODO: add component description #}
+{% endblock %}
+
 {% block content %}
   <section>
-    <h2 id="basic-pill">Basic Pill</h2>
-    <p class="hxSubBody">Added: v0.8.0</p>
+    <header>
+      <h2 id="basic-pill">Basic Pill</h2>
+      <p class="hxSubBody">Added: v0.8.0</p>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example" id="vue-pillDemo" v-cloak>
       <header>
         <form class="beta-hxForm">
-          <p>
-            <label for="txtContent" class="beta-hxFieldName">Content:</label>
-            <textarea
-              class="hxTextCtrl"
+          <hx-text-control>
+            <input
               id="txtContent"
+              type="text"
               v-model="content"
-            ></textarea>
-          </p>
+            />
+            <label for="txtContent">
+              Content
+            </label>
+          </hx-text-control>
+
           <fieldset>
             <legend class="beta-hxFieldName">Options</legend>
-            <div>
-              <input id="chkIsPersistent" type="checkbox" v-model="isPersistent" />
-              <label for="chkIsPersistent">Persist</label>
-            </div>
+            <hx-checkbox-control>
+              <input
+                id="chkIsPersistent"
+                type="checkbox"
+                v-model="isPersistent"
+              />
+              <label for="chkIsPersistent">
+                <hx-checkbox></hx-checkbox>
+                Persist
+              </label>
+            </hx-checkbox-control>
           </fieldset>
         </form>
       </header>
@@ -35,9 +54,10 @@ also:
       <div>
         <hx-pill
           :persist="isPersistent"
-          v-text="content"
           @dismiss="onEvent"
-        ></hx-pill>
+        >
+          {% raw %}{{content}}{% endraw %}
+        </hx-pill>
       </div>
 
       <footer>
@@ -47,31 +67,48 @@ also:
   </section>
 
   <section>
-    <h2 id="status-pill">Status Pill</h2>
-    <p class="hxSubBody">Added: v0.1.14</p>
+    <header>
+      <h2 id="status-pill">Status Pill</h2>
+      <p class="hxSubBody">Added: v0.1.14</p>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example" id="vue-statusPillDemo" v-cloak>
       <header>
         <form class="beta-hxForm">
-          <div>
-            <label for="selVariant" class="beta-hxFieldName">Variant</label>
+          <hx-select-control>
             <select id="selVariant" v-model="variant">
               <option v-for="_variant in variants" :value="_variant">
-                {% raw %}{{ _variant.label }}{% endraw %}
+                {% raw %}{{_variant.label}}{% endraw %}
               </option>
             </select>
-          </div>
+            <hx-select></hx-select>
+            <label for="selVariant">
+              Variant
+            </label>
+          </hx-select-control>
+
           <fieldset>
             <legend class="beta-hxFieldname">Options</legend>
-            <div>
-              <input id="chkIsFilled" type="checkbox" v-model="isFilled">
-              <label for="chkIsFilled">Filled</label>
-            </div>
+            <hx-checkbox-control>
+              <input
+                id="chkIsFilled"
+                type="checkbox"
+                v-model="isFilled"
+              />
+              <label for="chkIsFilled">
+                <hx-checkbox></hx-checkbox>
+                Filled
+              </label>
+            </hx-checkbox-control>
           </fieldset>
         </form>
       </header>
 
       <div class="status-demo">
-        <hx-status :class="cssClasses" v-text="variant.label"></hx-status>
+        <hx-status :class="cssClasses">
+          {% raw %}{{variant.label}}{% endraw %}
+        </hx-status>
       </div>
 
       <footer>
@@ -81,8 +118,8 @@ also:
           {% endcode %}
         </template>
         <template v-else>
-          {% code 'html' %}
-            {% raw %}<hx-status class="{{cssClasses}}">...</hx-status>{% endraw %}
+          {% code 'html' %}{% raw %}
+            <hx-status class="{{cssClasses}}">...</hx-status>{% endraw %}
           {% endcode %}
         </template>
       </footer>

--- a/docs/components/popovers/index.html
+++ b/docs/components/popovers/index.html
@@ -9,20 +9,31 @@ also:
 {% import '_utils.njk' as utils %}
 {% extends 'component.njk' %}
 
+{% block page_header %}
+  {# TODO: add component description #}
+{% endblock %}
+
 {% block content %}
   <section>
-    <h2 id="basic-popover">Basic Popover</h2>
+    <header>
+      <h2 id="basic-popover">Basic Popover</h2>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example" id="vue-popoverDemo" v-cloak>
       <header>
         <form class="beta-hxForm">
-          <div>
-            <label for="selPosition" class="beta-hxFieldName">Position</label>
+          <hx-select-control>
             <select id="selPosition" v-model="position">
               <option v-for="_position in positions" :value="_position">
-                {% raw %}{{ _position.label }}{% endraw %}
+                {% raw %}{{_position.label}}{% endraw %}
               </option>
             </select>
-          </div>
+            <hx-select></hx-select>
+            <label for="selPosition">
+              Position
+            </label>
+          </hx-select-control>
         </form>
       </header>
 
@@ -55,7 +66,7 @@ also:
           <hx-disclosure aria-controls="demoPopover" class="hxBtn">
             Toggle
           </hx-disclosure>
-          <hx-popover id="demoPopover" position="{{ position.value }}">
+          <hx-popover id="demoPopover" position="{{position.value}}">
             <header>
               Popover Header
             </header>
@@ -77,18 +88,25 @@ also:
   </section>
 
   <section>
-    <h2 id="scrolling-popover">Scrolling Popover</h2>
+    <header>
+      <h2 id="scrolling-popover">Scrolling Popover</h2>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example" id="vue-scrollingPopoverDemo" v-cloak>
       <header>
         <form class="beta-hxForm">
-          <div>
-            <label for="selPosition" class="beta-hxFieldName">Position</label>
-            <select id="selPosition" v-model="position">
+          <hx-select-control>
+            <select id="selPositionScroll" v-model="position">
               <option v-for="_position in positions" :value="_position">
-                {% raw %}{{ _position.label }}{% endraw %}
+                {% raw %}{{_position.label}}{% endraw %}
               </option>
             </select>
-          </div>
+            <hx-select></hx-select>
+            <label for="selPositionScroll">
+              Position
+            </label>
+          </hx-select-control>
         </form>
       </header>
 
@@ -106,7 +124,7 @@ also:
           </header>
 
           <hx-div scroll="vertical">
-            {{ utils.lorem(3) }}
+            {{utils.lorem(3)}}
           </hx-div>
 
           <footer>
@@ -122,7 +140,7 @@ also:
             Toggle
           </hx-disclosure>
 
-          <hx-popover id="scrollingPopoverDemo" position="{{ position.value }}">
+          <hx-popover id="scrollingPopoverDemo" position="{{position.value}}">
             <header>
               Popover Header
             </header>
@@ -141,11 +159,14 @@ also:
         {% endcode %}
       </footer>
     </div>
-    <p class="hxSubdued hxSubBody">
-      <hx-icon type="info-circle"></hx-icon>
-      Please refer to <a href="components/box/#scrolling-containers">
-      "Scrolling Containers"</a> documentation for more information about
-      scrolling popover content.
-    </p>
+
+    <footer>
+      <p class="hxSubdued hxSubBody">
+        <hx-icon type="info-circle"></hx-icon>
+        Please refer to <a href="components/box/#scrolling-containers">
+        "Scrolling Containers"</a> documentation for more information about
+        scrolling popover content.
+      </p>
+    </footer>
   </section>
 {% endblock %}

--- a/docs/components/radios/index.html
+++ b/docs/components/radios/index.html
@@ -8,30 +8,53 @@ also:
   elements/hx-radio: <hx-radio>
 ---
 {% extends 'component.njk' %}
+
+{% block page_header %}
+  {# TODO: add component description #}
+{% endblock %}
+
 {% block content %}
   <section>
-    <h2 id="basic-radio">Basic Radio</h2>
+    <header>
+      <h2 id="basic-radio">Basic Radio</h2>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example" id="vue-radioDemo" v-cloak>
       <header>
         <form class="beta-hxForm">
           <fieldset>
             <legend class="beta-hxFieldName">Options</legend>
             <hx-checkbox-control>
-              <input id="chkIsChecked" type="checkbox" v-model="isChecked" />
+              <input
+                id="chkIsChecked"
+                type="checkbox"
+                v-model="isChecked"
+              />
               <label for="chkIsChecked">
                 <hx-checkbox></hx-checkbox>
                 With Default Selection
               </label>
             </hx-checkbox-control>
+
             <hx-checkbox-control>
-              <input id="chkIsDisabled" type="checkbox" v-model="isDisabled" />
+              <input
+                id="chkIsDisabled"
+                type="checkbox"
+                v-model="isDisabled"
+              />
               <label for="chkIsDisabled">
                 <hx-checkbox></hx-checkbox>
                 Disabled
               </label>
             </hx-checkbox-control>
+
             <hx-checkbox-control>
-              <input id="chkIsRequired" type="checkbox" v-model="isRequired" />
+              <input
+                id="chkIsRequired"
+                type="checkbox"
+                v-model="isRequired"
+              />
               <label for="chkIsRequired">
                 <hx-checkbox></hx-checkbox>
                 Required
@@ -40,6 +63,7 @@ also:
           </fieldset>
         </form>
       </header>
+
       <div>
         <hx-radio-set>
           <hx-radio-control>
@@ -71,15 +95,19 @@ also:
           </hx-radio-control>
         </hx-radio-set>
       </div>
+
       <footer>
         <pre><code v-text="snippet"></code></pre>
       </footer>
     </div>
-    <p class="hxSubdued hxSubBody">
-      <hx-icon type="info-circle"></hx-icon>
-      Webkit-based browsers (e.g., Chrome, Safari, etc.) do not match the
-      <code>:required</code> CSS psuedo-class to radios in a single-item
-      radio group.
-    </p>
+
+    <footer>
+      <p class="hxSubdued hxSubBody">
+        <hx-icon type="info-circle"></hx-icon>
+        Webkit-based browsers (e.g., Chrome, Safari, etc.) do not match the
+        <code>:required</code> CSS psuedo-class to radios in a single-item
+        radio group.
+      </p>
+    </footer>
   </section>
 {% endblock %}

--- a/docs/components/reveals/index.html
+++ b/docs/components/reveals/index.html
@@ -7,18 +7,34 @@ also:
   elements/hx-reveal: <hx-reveal>
 ---
 {% extends 'component.njk' %}
+
+{% block page_header %}
+  {# TODO: add component description #}
+{% endblock %}
+
 {% block content %}
   <section>
-    <h2 id="basic-reveal">Basic Reveal</h2>
+    <header>
+      <h2 id="basic-reveal">Basic Reveal</h2>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example" id="vue-revealDemo" v-cloak>
       <header>
         <form class="beta-hxForm">
           <fieldset>
             <legend class="beta-hxFieldName">Options</legend>
-            <div>
-              <input id="chkIsDisabled" type="checkbox" v-model="isDisabled" />
-              <label for="chkIsDisabled">Disabled</label>
-            </div>
+            <hx-checkbox-control>
+              <input
+                id="chkIsDisabled"
+                type="checkbox"
+                v-model="isDisabled"
+              />
+              <label for="chkIsDisabled">
+                <hx-checkbox></hx-checkbox>
+                Disabled
+              </label>
+            </hx-checkbox-control>
           </fieldset>
         </form>
       </header>
@@ -39,7 +55,11 @@ also:
       <footer>
         <template v-if="isDisabled">
           {% code 'html' %}
-            <hx-disclosure aria-controls="elReveal" class="hxBtn" disabled>
+            <hx-disclosure
+              aria-controls="elReveal"
+              class="hxBtn"
+              disabled
+            >
               Click me to show content!
             </hx-disclosure>
             <hx-reveal id="elReveal">
@@ -50,7 +70,10 @@ also:
 
         <template v-else>
           {% code 'html' %}
-            <hx-disclosure aria-controls="elReveal" class="hxBtn">
+            <hx-disclosure
+              aria-controls="elReveal"
+              class="hxBtn"
+            >
               Click me to show content!
             </hx-disclosure>
             <hx-reveal id="elReveal">

--- a/docs/components/search/index.html
+++ b/docs/components/search/index.html
@@ -7,40 +7,68 @@ also:
   elements/hx-search-assistance: <hx-search-assistance>
 ---
 {% extends 'component.njk' %}
+
+{% block page_header %}
+  {# TODO: add component description #}
+{% endblock %}
+
 {% block content %}
   <section>
-    <h2 id="basic-search">Basic Search</h2>
+    <header>
+      <h2 id="basic-search">Basic Search</h2>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example" id="vue-searchDemo" v-cloak>
       <header>
         <form class="beta-hxForm">
-          <p>
-            <label for="txtPlaceholder" class="beta-hxFieldName">Placeholder</label>
+          <hx-text-control>
             <input
-              class="hxTextCtrl"
               id="txtPlaceholder"
-              placeholder="e.g. Search..."
+              type="text"
               v-model="placeholder"
             />
-          </p>
-          <p>
-            <label for="txtValue" class="beta-hxFieldName">Value</label>
+            <label for="txtPlaceholder">
+              Placeholder
+            </label>
+          </hx-text-control>
+
+          <hx-text-control>
             <input
-              class="hxTextCtrl"
               id="txtValue"
-              placeholder="e.g. kittens"
+              type="text"
               v-model="searchValue"
             />
-          </p>
+            <label for="txtValue">
+              Value
+            </label>
+          </hx-text-control>
+
           <fieldset>
             <legend class="beta-hxFieldName">Options</legend>
-            <div>
-              <input id="chkIsDisabled" type="checkbox" v-model="isDisabled" />
-              <label for="chkIsDisabled">Disabled</label>
-            </div>
-            <div>
-              <input id="chkIsInvalid" type="checkbox" v-model="isInvalid" />
-              <label for="chkIsInvalid">Invalid</label>
-            </div>
+            <hx-checkbox-control>
+              <input
+                id="chkIsDisabled"
+                type="checkbox"
+                v-model="isDisabled"
+              />
+              <label for="chkIsDisabled">
+                <hx-checkbox></hx-checkbox>
+                Disabled
+              </label>
+            </hx-checkbox-control>
+
+            <hx-checkbox-control>
+              <input
+                id="chkIsInvalid"
+                type="checkbox"
+                v-model="isInvalid"
+              />
+              <label for="chkIsInvalid">
+                <hx-checkbox></hx-checkbox>
+                Invalid
+              </label>
+            </hx-checkbox-control>
           </fieldset>
         </form>
       </header>
@@ -63,8 +91,12 @@ also:
   </section>
 
   <section>
-    <h2 id="search-assistance">Search Assistance</h2>
-    <p class="hxSubBody">Added: v0.6.0</p>
+    <header>
+      <h2 id="search-assistance">Search Assistance</h2>
+      <p class="hxSubBody">Added: v0.6.0</p>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example" id="vue-searchAssistanceDemo" v-cloak>
       <div>
         <hx-search
@@ -76,13 +108,15 @@ also:
           id="assisted-hx-search"
         ></hx-search>
         <hx-search-assistance relative-to="assisted-hx-search" ref="search">
-          <header>Search for "<span v-text="searchValue"></span>"</header>
+          {% raw %}
+          <header>Search for "{{searchValue}}"</header>
           <section v-if="hasValue">
             <header>Category Header</header>
-            <button class="hxSearchSuggestion">Here is a possible <b v-text="searchValue"></b></button>
-            <button class="hxSearchSuggestion">Here is a possible <b v-text="searchValue"></b></button>
-            <button class="hxSearchSuggestion">Here is a possible <b v-text="searchValue"></b></button>
+            <button class="hxSearchSuggestion">Here is a possible <b>{{searchValue}}</b></button>
+            <button class="hxSearchSuggestion">Here is a possible <b>{{searchValue}}</b></button>
+            <button class="hxSearchSuggestion">Here is a possible <b>{{searchValue}}</b></button>
           </section>
+          {% endraw %}
         </hx-search-assistance>
       </div>
 
@@ -106,9 +140,12 @@ also:
         {% endcode %}
       </footer>
     </div>
-    <p class="hxSubdued hxSubBody">
-      <hx-icon type="info-circle"></hx-icon>
-      Behavior to show/hide search assistance may differ in your app.
-    </p>
+
+    <footer>
+      <p class="hxSubdued hxSubBody">
+        <hx-icon type="info-circle"></hx-icon>
+        Behavior to show/hide search assistance may differ in your app.
+      </p>
+    </footer>
   </section>
 {% endblock %}

--- a/docs/components/selector-strips/index.html
+++ b/docs/components/selector-strips/index.html
@@ -3,10 +3,19 @@ title: Selector Strips
 minver: 0.8.0
 ---
 {% extends 'component.njk' %}
+
+{% block page_header %}
+  {# TODO: add component description #}
+{% endblock %}
+
 {% block content %}
   <section>
-    <h2 id="multi-select">Multi-Select</h2>
-    <p>a.k.a. "checkbox strip"<p>
+    <header>
+      <h2 id="multi-select">Multi-Select</h2>
+      <p>a.k.a. "checkbox strip"<p>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example">
       <div>
         <div class="hxSelector">
@@ -63,8 +72,12 @@ minver: 0.8.0
   </section>
 
   <section>
-    <h2 id="single-select">Single-Select</h2>
-    <p>a.k.a. "radio strip"<p>
+    <header>
+      <h2 id="single-select">Single-Select</h2>
+      <p>a.k.a. "radio strip"<p>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example">
       <div>
         <div class="hxSelector hxRadio">

--- a/docs/components/stepper/index.html
+++ b/docs/components/stepper/index.html
@@ -1,17 +1,24 @@
 ---
 title: Stepper
+beta: true
 also:
   components/accordions: Accordions
   elements/hx-accordion-panel: <hx-accordion-panel>
   elements/hx-accordion: <hx-accordion>
 ---
 {% extends 'component.njk' %}
+
+{% block page_header %}
+  {# TODO: add component description #}
+{% endblock %}
+
 {% block content %}
-  <hx-alert type="warning" status="BETA" persist>
-    This component is not recommended for production use.
-  </hx-alert>
   <section>
-    <h2 id="basic-stepper">Basic Stepper</h2>
+    <header>
+      <h2 id="basic-stepper">Basic Stepper</h2>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example" id="vue-stepperDemo" v-cloak>
       <div>
         <hx-accordion

--- a/docs/components/tables/index.html
+++ b/docs/components/tables/index.html
@@ -3,33 +3,77 @@ title: Tables
 minver: 0.1.7
 ---
 {% extends 'component.njk' %}
+
+{% block page_header %}
+  {# TODO: add component description #}
+{% endblock %}
+
 {% block content %}
   <section>
-    <h2 id="basic-table">Basic Table</h2>
+    <header>
+      <h2 id="basic-table">Basic Table</h2>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example" id="vue-tableDemo" v-cloak>
       <header>
         <form class="beta-hxForm">
           <fieldset>
             <legend class="beta-hxFieldName">Data Density</legend>
-            <div>
-              <input id="radNormal" type="radio" name="density" v-model="isCondensed" :value="false" />
-              <label for="radNormal">Normal</label>
-            </div>
-            <div>
-              <input id="radCondensed" type="radio" name="density" v-model="isCondensed" :value="true" />
-              <label for="radCondensed">Condensed</label>
-            </div>
+            <hx-radio-control>
+              <input
+                id="radNormal"
+                name="density"
+                type="radio"
+                v-model="isCondensed"
+                :value="false"
+              />
+              <label for="radNormal">
+                <hx-radio></hx-radio>
+                Normal
+              </label>
+            </hx-radio-control>
+
+            <hx-radio-control>
+              <input
+                id="radCondensed"
+                name="density"
+                type="radio"
+                v-model="isCondensed"
+                :value="true"
+              />
+              <label for="radCondensed">
+                <hx-radio></hx-radio>
+                Condensed
+              </label>
+            </hx-radio-control>
           </fieldset>
+
           <fieldset>
             <legend class="beta-hxFieldName">Options</legend>
-            <div>
-              <input id="chkBound" type="checkbox" v-model="isBound" />
-              <label for="chkBound">Bound</label>
-            </div>
-            <div>
-              <input id="chkHoverable" type="checkbox" v-model="isHoverable" />
-              <label for="chkHoverable">Hoverable</label>
-            </div>
+            <hx-checkbox-control>
+              <input
+                id="chkBound"
+                type="checkbox"
+                v-model="isBound"
+              />
+              <label for="chkBound">
+                <hx-checkbox></hx-checkbox>
+                Bound
+              </label>
+            </hx-checkbox-control>
+
+            <hx-checkbox-control>
+              <input
+                id="chkHoverable"
+                type="checkbox"
+                v-model="isHoverable"
+              />
+              <label for="chkHoverable">
+                <hx-checkbox></hx-checkbox>
+                Hoverable
+              </label>
+            </hx-checkbox-control>
           </fieldset>
         </form>
       </header>
@@ -89,11 +133,14 @@ minver: 0.1.7
   </section>
 
   <section><!-- Selection Table -->
-    <h2 id="selection-table">Selection Table</h2>
-    <p>
-      Use the <code>.hxControl</code> CSS class on table cells that contain
-      a checkbox.
-    </p>
+    <header>
+      <h2 id="selection-table">Selection Table</h2>
+      <p>
+        Use the <code>.hxControl</code> CSS class on table cells that contain
+        a checkbox.
+      </p>
+    </header>
+
     <div class="example">
       <div>
         <table class="hxTable">
@@ -101,7 +148,8 @@ minver: 0.1.7
           <thead>
             <tr>
               <th class="hxControl">
-                <hx-checkbox></hx-checkbox>
+                {# TODO: update to hx-checkbox-control (with visually hidden label) #}
+                <input type="checkbox" />
               </th>
               <th>Rank</th>
               <th>Name</th>
@@ -112,7 +160,8 @@ minver: 0.1.7
           <tbody>
             <tr>
               <th class="hxControl">
-                <hx-checkbox></hx-checkbox>
+                {# TODO: update to hx-checkbox-control (with visually hidden label) #}
+                <input type="checkbox" />
               </th>
               <td>1</td>
               <td>Katy Perry</td>
@@ -123,7 +172,8 @@ minver: 0.1.7
             </tr>
             <tr>
               <th class="hxControl">
-                <hx-checkbox></hx-checkbox>
+                {# TODO: update to hx-checkbox-control (with visually hidden label) #}
+                <input type="checkbox" />
               </th>
               <td>2</td>
               <td>Justin Beiber</td>
@@ -134,7 +184,8 @@ minver: 0.1.7
             </tr>
             <tr>
               <th class="hxControl">
-                <hx-checkbox></hx-checkbox>
+                {# TODO: update to hx-checkbox-control (with visually hidden label) #}
+                <input type="checkbox" />
               </th>
               <td>3</td>
               <td>Barack Obama</td>
@@ -160,7 +211,7 @@ minver: 0.1.7
             <thead>
               <tr>
                 <th class="hxControl">
-                  <hx-checkbox></hx-checkbox>
+                  <input type="checkbox" />
                 </th>
                 <th>Rank</th>
                 <th>Name</th>
@@ -171,7 +222,7 @@ minver: 0.1.7
             <tbody>
               <tr>
                 <th class="hxControl">
-                  <hx-checkbox></hx-checkbox>
+                  <input type="checkbox" />
                 </th>
                 <td>1</td>
                 <td>Katy Perry</td>
@@ -191,11 +242,14 @@ minver: 0.1.7
   </section>
 
   <section><!-- Action Table -->
-    <h2 id="action-table">Action Table</h2>
-    <p>
-      Use the <code>.hxControl</code> CSS class on table cells that contain
-      a cog menu.
-    </p>
+    <header>
+      <h2 id="action-table">Action Table</h2>
+      <p>
+        Use the <code>.hxControl</code> CSS class on table cells that contain
+        a cog menu.
+      </p>
+    </header>
+
     <div class="example">
       <div>
         <table class="hxTable">

--- a/docs/components/tabs/index.html
+++ b/docs/components/tabs/index.html
@@ -8,13 +8,18 @@ also:
   elements/hx-tabpanel: <hx-tabpanel>
   elements/hx-tabset: <hx-tabset>
 ---
-{% set contentClasses = 'docs-tabset' %}
 {% extends 'component.njk' %}
+{% set contentClasses = 'docs-tabset' %}
+
+{% block page_header %}
+  {# TODO: add component description #}
+{% endblock %}
 
 {% block content %}
   <section>
     <header>
       <h2 id="basic-tabset">Basic Tabset</h2>
+      {# TODO: add section description #}
     </header>
 
     <div class="example resizable">

--- a/docs/components/text-input/index.html
+++ b/docs/components/text-input/index.html
@@ -6,8 +6,9 @@ also:
   elements/hx-text-control/index.html: <hx-text-control>
 ---
 {% extends 'component.njk' %}
+
 {% block page_header %}
-  <p class="comfortable">
+  <p>
     The {{page.title}} component provides markup to define a
     single-line text control.
   </p>
@@ -15,26 +16,27 @@ also:
 
 {% block content %}
   <section>
-    <h2 id="basic-text-input">Basic Text Input</h2>
+    <header>
+      <h2 id="basic-text-input">Basic Text Input</h2>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example" id="vue-textInputDemo" v-cloak>
       <header>
         <form class="beta-hxForm">
-          <div>
-            <hx-text-control>
-              <input
-                id="txtLabel"
-                type="text"
-                v-model="label"
-              />
-              <label for="txtLabel">
-                Label Text
-              </label>
-            </hx-text-control>
-          </div>
+          <hx-text-control>
+            <input
+              id="txtLabel"
+              type="text"
+              v-model="label"
+            />
+            <label for="txtLabel">
+              Label Text
+            </label>
+          </hx-text-control>
 
           <fieldset>
             <legend class="beta-hxFieldName">Label Annotation</legend>
-
             <hx-checkbox-control>
               <input
                 id="chkHasAsterisk"
@@ -102,9 +104,10 @@ also:
           />
           <label
             for="txtInputDemo"
-            v-text="label"
             :class="{ hxOptional: hasOptional, hxRequired: hasAsterisk }"
-          ></label>
+          >
+            {% raw %}{{label}}{% endraw %}
+          </label>
         </hx-text-control>
       </div>
 
@@ -112,16 +115,23 @@ also:
         <pre><code v-text="snippet"></code></pre>
       </footer>
     </div>
-    <p class="hxSubBody hxSubdued">
-      <hx-icon type="exclamation-triangle"></hx-icon>
-      The <code>&lt;input&gt;</code> element <i>must</i> have the
-      <code>type="text"</code> attribute, in order for CSS styles
-      to apply.
-    </p>
+
+    <footer>
+      <p class="hxSubBody hxSubdued">
+        <hx-icon type="exclamation-triangle"></hx-icon>
+        The <code>&lt;input&gt;</code> element <i>must</i> have the
+        <code>type="text"</code> attribute, in order for CSS styles
+        to apply.
+      </p>
+    </footer>
   </section>
 
   <section>
-    <h2 id="prefixed">Prefixed</h2>
+    <header>
+      <h2 id="prefixed">Prefixed</h2>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example">
       <div>
         <hx-text-control>
@@ -158,7 +168,11 @@ also:
   </section>
 
   <section>
-    <h2 id="suffixed">Suffixed</h2>
+    <header>
+      <h2 id="suffixed">Suffixed</h2>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example">
       <div>
         <hx-text-control>

--- a/docs/components/textarea/index.html
+++ b/docs/components/textarea/index.html
@@ -6,8 +6,9 @@ also:
   elements/hx-textarea-control/index.html: <hx-textarea-control>
 ---
 {% extends 'component.njk' %}
+
 {% block page_header %}
-  <p class="comfortable">
+  <p>
     The {{page.title}} component provides markup to define a
     multi-line text control.
   </p>
@@ -15,26 +16,27 @@ also:
 
 {% block content %}
   <section>
-    <h2 id="basic-textarea">Basic Textarea</h2>
+    <header>
+      <h2 id="basic-textarea">Basic Textarea</h2>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example" id="vue-textareaDemo" v-cloak>
       <header>
         <form class="beta-hxForm">
-          <div>
-            <hx-text-control>
-              <input
-                id="txtLabel"
-                type="text"
-                v-model="label"
-              />
-              <label for="txtLabel">
-                Label Text
-              </label>
-            </hx-text-control>
-          </div>
+          <hx-text-control>
+            <input
+              id="txtLabel"
+              type="text"
+              v-model="label"
+            />
+            <label for="txtLabel">
+              Label Text
+            </label>
+          </hx-text-control>
 
           <fieldset>
             <legend class="beta-hxFieldName">Label Annotation</legend>
-
             <hx-checkbox-control>
               <input
                 id="chkHasAsterisk"
@@ -101,9 +103,10 @@ also:
           ></textarea>
           <label
             for="txtAreaDemo"
-            v-text="label"
             :class="{ hxOptional: hasOptional, hxRequired: hasAsterisk }"
-          ></label>
+          >
+            {% raw %}{{label}}{% endraw %}
+          </label>
         </hx-textarea-control>
       </div>
 

--- a/docs/components/toasts/index.html
+++ b/docs/components/toasts/index.html
@@ -5,35 +5,57 @@ also:
   elements/hx-toast: <hx-toast>
 ---
 {% extends 'component.njk' %}
+
+{% block page_header %}
+  <hx-alert type="info" status="note" persist>
+    Currently, only CTA and dismiss functionality of the toast itself has been
+    implemented. Positioning, stacking, animation, etc. functionality will be coming soon.
+  </hx-alert>
+  {# TODO: add component description #}
+{% endblock %}
+
 {% block content %}
   <section>
-    <hx-alert type="info" status="note" persist>
-      Currently, only CTA and dismiss functionality of the toast itself has been
-      implemented. Positioning, stacking, animation, etc. functionality will be coming soon.
-    </hx-alert>
-  </section>
+    <header>
+      <h2 id="basic-toast">Basic Toast</h2>
+      {# TODO: add section description #}
+    </header>
 
-  <section>
-    <h2 id="basic-toast">Basic Toast</h2>
     <div class="example" id="vue-toastDemo" v-cloak>
       <header>
         <form class="beta-hxForm">
-          <div>
-            <label for="selType" class="beta-hxFieldName">Type</label>
+          <hx-select-control>
             <select id="selType" v-model="type">
               <option v-for="_type in types" :value="_type">
-                {% raw %}{{ _type.label }}{% endraw %}
+                {% raw %}{{_type.label}}{% endraw %}
               </option>
             </select>
-          </div>
-          <p>
-            <label for="txtCta" class="beta-hxFieldName">CTA</label>
-            <input id="txtCta" class="hxTextCtrl" v-model="cta" />
-          </p>
-          <p>
-            <label for="txtContent" class="beta-hxFieldName">Content</label>
-            <textarea id="txtContent" class="hxTextCtrl" v-model="content"></textarea>
-          </p>
+            <hx-select></hx-select>
+            <label for="selType">
+              Type
+            </label>
+          </hx-select-control>
+
+          <hx-text-control>
+            <input
+              id="txtCta"
+              type="text"
+              v-model="cta"
+            />
+            <label for="txtCta">
+              CTA
+            </label>
+          </hx-text-control>
+
+          <hx-textarea-control>
+            <textarea
+              id="txtContent"
+              v-model="content"
+            ></textarea>
+            <label for="txtContent">
+              Content
+            </label>
+          </hx-textarea-control>
         </form>
       </header>
 

--- a/docs/components/tooltips/index.html
+++ b/docs/components/tooltips/index.html
@@ -6,31 +6,35 @@ also:
   elements/hx-tooltip: <hx-tooltip>
 ---
 {% extends 'component.njk' %}
+
+{% block page_header %}
+  <p>
+    A tooltip is a component that provides descriptive information related to an element when
+    the element receives keyboard focus or the mouse hovers over it.
+  </p>
+{% endblock %}
+
 {% block content %}
   <section>
-    <p class="comfortable">
-      A tooltip is a component that provides descriptive information related to an element when
-      the element receives keyboard focus or the mouse hovers over it.
-    </p>
-    <p class="comfortable">
-      Tooltips should not contain interactive content. Consider using the
-      <a href="components/popovers">Popover</a> component for interactive content.
-    </p>
-  </section>
+    <header>
+      <h2 id="basic-tooltip">Basic Tooltip</h2>
+      {# TODO: add section description #}
+    </header>
 
-  <section>
-    <h2 id="basic-tooltip">Basic Tooltip</h2>
     <div class="example" id="vue-tooltipDemo" v-cloak>
       <header>
         <form class="beta-hxForm">
-          <div>
-            <label for="selPosition" class="beta-hxFieldName">Position</label>
+          <hx-select-control>
             <select id="selPosition" v-model="position">
               <option v-for="_position in positions" :value="_position">
-                {% raw %}{{ _position.label }}{% endraw %}
+                {% raw %}{{_position.label}}{% endraw %}
               </option>
             </select>
-          </div>
+            <hx-select></hx-select>
+            <label for="selPosition">
+              Position
+            </label>
+          </hx-select-control>
         </form>
       </header>
 
@@ -39,9 +43,7 @@ also:
           <hx-icon id="icon1" type="help-circle"></hx-icon>
         </p>
         <hx-tooltip for="icon1" :position="position.value">
-        {% raw %}
-          {{position.label}} Tooltip
-        {% endraw %}
+          {% raw %}{{position.label}} Tooltip{% endraw %}
         </hx-tooltip>
       </div>
 
@@ -56,13 +58,24 @@ also:
         {% endcode %}
       </footer>
     </div>
-    <!--
-    <p class="hxSubdued hxSubBody comfortable">
-      <hx-icon type="exclamation-triangle"></hx-icon>
-      For accessibility, make sure that the control element can receive focus
-      (i.e., use a native focusable element or an element with a non-negative
-      <code>tabindex</code> attribute).
-    </p>
-    -->
+  </section>
+
+  <section>
+    <header>
+      <h2 id="accessibility">Accessibility</h2>
+      {# TODO: add section description #}
+    </header>
+
+    <ol class="hxList">
+      <li>
+        Make sure that the control element can receive focus (i.e., use a native
+        focusable element or an element with a non-negative
+        <code>tabindex</code> attribute).
+      </li>
+      <li>
+        Tooltips should not contain interactive content. Consider using the
+        <a href="components/popovers">Popover</a> component for interactive content.
+      </li>
+    </ol>
   </section>
 {% endblock %}

--- a/docs/components/typography/index.html
+++ b/docs/components/typography/index.html
@@ -6,9 +6,18 @@ also:
   elements/hx-error: <hx-error>
 ---
 {% extends 'component.njk' %}
+
+{% block page_header %}
+  {# TODO: add component description #}
+{% endblock %}
+
 {% block content %}
   <section><!-- Typefaces -->
-    <h2 id="typefaces">Typefaces</h2>
+    <header>
+      <h2 id="typefaces">Typefaces</h2>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example">
       <div class="demo-typography">
         <div class="hxRow">
@@ -32,7 +41,11 @@ also:
   </section>
 
   <section><!-- Headings -->
-    <h2 id="headers">Headings</h2>
+    <header>
+      <h2 id="headings">Headings</h2>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example">
       <div>
         <h1>Heading One</h1>
@@ -97,11 +110,14 @@ also:
   </section>
 
   <section><!-- Subdued -->
-    <h2 id="subdued">Subdued</h2>
-    <p>
-      Add the <code>.hxSubdued</code> CSS class to any element to apply a
-      muted appearance.
-    </p>
+    <header>
+      <h2 id="subdued">Subdued</h2>
+      <p>
+        Add the <code>.hxSubdued</code> CSS class to any element to apply a
+        muted appearance.
+      </p>
+    </header>
+
     <div class="example">
       <div>
         <div class="hxSubdued">div.hxSubdued</div>
@@ -122,10 +138,15 @@ also:
   </section>
 
   <section><!-- Caption -->
-    <h2 id="caption">Caption</h2>
+    <header>
+      <h2 id="caption">Caption</h2>
+      {# TODO: add section description #}
+    </header>
+
     <p>
       Apply the Helix "caption" style with any of the following configurations:
     </p>
+
     <ul class="hxList">
       <li>
         A <code>&lt;caption&gt;</code> element within a
@@ -139,6 +160,7 @@ also:
         Add the <code>.hxCaption</code> CSS class to any element
       </li>
     </ul>
+
     <div class="example">
       <div>
         <figure class="hxFigure">
@@ -167,14 +189,20 @@ also:
   </section>
 
   <section><!-- Sub-Body -->
-    <h2 id="sub-body">Sub-Body</h2>
+    <header>
+      <h2 id="sub-body">Sub-Body</h2>
+      {# TODO: add section description #}
+    </header>
+
     <p>
       Apply the "sub-body" style with any of the following:
     </p>
+
     <ul class="hxList">
       <li>A <code>&lt;small&gt;</code> element</li>
       <li>Add the <code>.hxSubBody</code> CSS class to any element</li>
     </ul>
+
     <div class="example">
       <div>
         <small>small</small>
@@ -192,17 +220,25 @@ also:
   </section>
 
   <section><!-- Links -->
-    <h2 id="links">Links</h2>
-    <p>
-      Links should be used to refer a user to a resource or location.
-    </p>
-    <hx-alert type="info" status="note" persist>
-      Buttons are better suited to initiate in-page actions.
-    </hx-alert>
-    <hx-alert type="warning" status="warning" persist>
-      Adding the <code>disabled</code> attribute to a link <b>will not</b>
-      prevent user interaction.
-    </hx-alert>
+    <header>
+      <h2 id="links">Links</h2>
+      <p>
+        Hyperlinks (a.k.a., links) should be used to navigate a user to a
+        resource or location.
+      </p>
+    </header>
+
+    <ul class="hxList">
+      <li>
+        <a href="components/buttons">Buttons</a> are better suited to
+        initiate in-page actions.
+      </li>
+      <li>
+        Adding the <code>disabled</code> attribute to a link does not
+        prevent user interaction.
+      </li>
+    </ul>
+
     <div class="example">
       <div>
         <a href="#">Link Text</a>
@@ -217,11 +253,14 @@ also:
   </section>
 
   <section><!-- Inline Code -->
-    <h2 id="inline-code">Inline Code</h2>
-    <p>
-      Use the <code>&lt;code&gt;</code> element to differentiate descriptive
-      text from code snippets.
-    </p>
+    <header>
+      <h2 id="inline-code">Inline Code</h2>
+      <p>
+        Use the <code>&lt;code&gt;</code> element to differentiate descriptive
+        text from code snippets.
+      </p>
+    </header>
+
     <div class="example">
       <div>
         <p>
@@ -240,11 +279,14 @@ also:
   </section>
 
   <section><!-- Keyboard -->
-    <h2 id="keyboard">Keyboard</h2>
-    <p>
-      Use the <code>&lt;kbd&gt;</code> element to differentiate descriptive text
-      from instructional key presses.
-    </p>
+    <header>
+      <h2 id="keyboard">Keyboard</h2>
+      <p>
+        Use the <code>&lt;kbd&gt;</code> element to differentiate descriptive text
+        from instructional key presses.
+      </p>
+    </header>
+
     <div class="example">
       <div>
         <p>
@@ -265,7 +307,11 @@ also:
   </section>
 
   <section><!-- Code Block -->
-    <h2 id="code-block">Code Block</h2>
+    <header>
+      <h2 id="code-block">Code Block</h2>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example">
       <div class="demo">
         <pre><code>[Insert Code Here]</code></pre>
@@ -280,10 +326,12 @@ also:
   </section>
 
   <section><!-- Error Text -->
-    <h2 id="error-text">Error Text</h2>
-    <p>
-      <small>Added: v0.4.0</small>
-    </p>
+    <header>
+      <h2 id="error-text">Error Text</h2>
+      <p class="hxSubBody">Added: v0.4.0</p>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example">
       <div>
         <hx-error>Error message goes here</hx-error>
@@ -298,11 +346,13 @@ also:
   </section>
 
   <section><!-- Syntax Highlighting -->
-    <h2 id="syntax-highlighting">Syntax Highlighting</h2>
-    <p>
-      HelixUI provides a built-in theme for use with the
-      <a href="https://highlightjs.org/">highlight.js</a> library.
-    </p>
+    <header>
+      <h2 id="syntax-highlighting">Syntax Highlighting</h2>
+      <p>
+        HelixUI provides a built-in theme for use with the
+        <a href="https://highlightjs.org/">highlight.js</a> library.
+      </p>
+    </header>
 
     <p>
       Below are some examples of the syntax highlighting in action.

--- a/docs/docs.less
+++ b/docs/docs.less
@@ -96,6 +96,7 @@ body.hxVertical {
   main {
     #Box.lg();
 
+    // PROTOTYPE: vertical spacing
     > * {
       // NOTE: do not apply the below margin in a horizontal layout
       margin: 3rem 0;
@@ -109,6 +110,7 @@ body.hxVertical {
       }
     }
 
+    // PROTOTYPE: vertical spacing
     // nested to prevent matching the global nav
     header {
       margin-bottom: 1rem;
@@ -247,7 +249,7 @@ min-version {
     border-color: @gray-300;
     border-style: solid;
     border-width: 0 0 1px;
-    margin: 0;
+    margin: 0 !important;
     padding: 1.25rem;
   }
 


### PR DESCRIPTION
* Use new basic form control components in demo configs
  * a.k.a., "dogfooding", "drinking our own Kool-aid", etc.
* Normalize Markup
  * Normalize indentation within `{% block %}` definitions
  * Normalize use of `<header>` to wrap section titles and descriptions
* Add TODOs for future documentation updates
  * missing component descriptions
  * missing section descriptions
  * missing table captions
  * etc.
* Normalize nunjucks formatting
  * Use `{{var}}` instead of `{{ var }}` (removed whitespace from within curly braces)
  * Use `{{var}}` instead of `v-text="var"` (snippets should be the only exception)
  * Space around `{% block %}` definitions
  * `{% import %}` before `{% extends %}` before `{% set ... %}`/`{% block %}`

JIRA: SURF-1619

### LGTM's
- [x] Dev LGTM
- [x] Zoom LGTM
