### PR TITLE
docs(guides): content and markup tweaks

### DIFF
--- a/docs/guides/faq/index.html
+++ b/docs/guides/faq/index.html
@@ -2,16 +2,17 @@
 title: Frequently Asked Questions
 ---
 {% extends 'guide.njk' %}
+
 {% block content %}
   <section>
-    <h2 id="what-are-web-components">What are Web Components?</h2>
-    <p class="comfortable">
-      Web Components are a set of W3C-standard APIs that enable developers to
-      create custom HTML tags that encapsulate markup, style, and behavior in
-      a framework-agnostic fashion.
-    </p>
-
-    <br />
+    <header>
+      <h2 id="what-are-web-components">What are Web Components?</h2>
+      <p>
+        Web Components are a set of W3C-standard APIs that enable developers to
+        create custom HTML tags that encapsulate markup, style, and behavior in
+        a framework-agnostic fashion.
+      </p>
+    </header>
 
     <dl class="hxList metadata">
       <div>
@@ -20,7 +21,7 @@ title: Frequently Asked Questions
           <p>
             Defines the mechanisms needed to reuse HTML documents in other HTML documents.
           </p>
-          <p class="comfortable hxSubBody hxSubdued">
+          <p class="hxSubBody hxSubdued">
             <hx-icon type="info-circle"></hx-icon>
             This technology was abandoned in favor of ES6 Modules in mid-2018.
           </p>
@@ -55,22 +56,25 @@ title: Frequently Asked Questions
         </dd>
       </div>
     </dl>
-    <p class="hxSubBody hxSubdued">
-      <hx-icon type="info-circle"></hx-icon>
-      Learn more about Web Components at
-      <a href="https://developer.mozilla.org/en-US/docs/Web/Web_Components">MDN</a>
-      and
-      <a href="https://www.webcomponents.org/">webcomponents.org</a>.
-    </p>
+
+    <footer>
+      <p class="hxSubBody hxSubdued">
+        <hx-icon type="info-circle"></hx-icon>
+        Learn more about Web Components at
+        <a href="https://developer.mozilla.org/en-US/docs/Web/Web_Components">MDN</a>
+        and
+        <a href="https://www.webcomponents.org/">webcomponents.org</a>.
+      </p>
+    </footer>
   </section>
 
   <section>
-    <h2 id="supported-browsers">Which Browsers are Supported?</h2>
-    <p>
-      HelixUI is built to be compatible with the following browsers:
-    </p>
-
-    <br />
+    <header>
+      <h2 id="supported-browsers">Which Browsers are Supported?</h2>
+      <p>
+        HelixUI is built to be compatible with the following browsers:
+      </p>
+    </header>
 
     <dl class="hxList metadata">
       <div>
@@ -94,21 +98,24 @@ title: Frequently Asked Questions
         <dd>latest</dd>
       </div>
     </dl>
-    <p class="hxSubBody hxSubdued">
-      <hx-icon type="info-circle"></hx-icon>
-      Visit the <a href="guides/polyfills">Polyfills</a> guide for more details about browser compatibility.
-    </p>
+
+    <footer>
+      <p class="hxSubBody hxSubdued">
+        <hx-icon type="info-circle"></hx-icon>
+        Visit the <a href="guides/polyfills">Polyfills</a> guide for more details about browser compatibility.
+      </p>
+    </footer>
   </section>
 
   <section>
-    <h2 id="supported-frameworks">Which Frameworks are Supported?</h2>
-    <p class="comfortable">
-      HelixUI is built on W3C-standard APIs, so compatibility with client-side
-      frameworks should be pretty good.  However, HelixUI is built to ensure
-      maximum compatibility with the following client-side frameworks:
-    </p>
-
-    <br />
+    <header>
+      <h2 id="supported-frameworks">Which Frameworks are Supported?</h2>
+      <p>
+        HelixUI is built on W3C-standard APIs, so compatibility with client-side
+        frameworks should be pretty good.  However, HelixUI is built to ensure
+        maximum compatibility with the following client-side frameworks:
+      </p>
+    </header>
 
     <dl class="hxList metadata">
       <div>
@@ -125,7 +132,7 @@ title: Frequently Asked Questions
       </div>
       <div>
         <dt>React</dt>
-        <dd>15+</dd>
+        <dd>16+</dd>
       </div>
       <div>
         <dt>VueJS</dt>
@@ -133,10 +140,12 @@ title: Frequently Asked Questions
       </div>
     </dl>
 
-    <p class="comfortable hxSubdued hxSubBody">
-      <hx-icon type="info-circle"></hx-icon> Visit
-      <a href="https://custom-elements-everywhere.com/">custom-elements-everywhere.com</a>
-      to check the compabitility of your chosen framework.
-    </p>
+    <footer>
+      <p class="hxSubdued hxSubBody">
+        <hx-icon type="info-circle"></hx-icon> Visit
+        <a href="https://custom-elements-everywhere.com/">custom-elements-everywhere.com</a>
+        to check the compabitility of your chosen framework.
+      </p>
+    </footer>
   </section>
 {% endblock %}

--- a/docs/guides/getting-started/index.html
+++ b/docs/guides/getting-started/index.html
@@ -2,18 +2,23 @@
 title: Getting Started with HelixUI
 ---
 {% extends 'guide.njk' %}
+
+{% block page_header %}
+  <p>
+    The HelixUI library provides front-end developers a set of reusable CSS
+    classes and HTML Custom Elements that adhere to Helix design standards.
+    Adopting the library will enable developers to build products with consistent
+    markup, styles, and behavior across a variety of frameworks.
+  </p>
+{% endblock %}
+
 {% block content %}
   <section>
-    <p class="comfortable">
-      The HelixUI library provides front-end developers a set of reusable CSS
-      classes and HTML Custom Elements that adhere to Helix design standards.
-      Adopting the library will enable developers to build products with consistent
-      markup, styles, and behavior across a variety of frameworks.
-    </p>
-  </section>
+    <header>
+      <h2 id="step-1">Step 1: Install HelixUI</h2>
+      {# TODO: add section description #}
+    </header>
 
-  <section>
-    <h2 id="step-1">Step 1: Install HelixUI</h2>
     <hx-tabset class="beta-hxBound">
       <hx-tablist>
         <hx-tab>NPM</hx-tab>
@@ -83,11 +88,14 @@ title: Getting Started with HelixUI
   </section>
 
   <section>
-    <h2 id="step-2">Step 2: Install Polyfills</h2>
-    <p class="comfortable">
-      To ensure that HelixUI has the minimum set of behavior required to function
-      across all supported browsers, the Web Components polyfills must be installed.
-    </p>
+    <header>
+      <h2 id="step-2">Step 2: Install Polyfills</h2>
+      <p>
+        To ensure that HelixUI has the minimum set of behavior required to function
+        across all supported browsers, the Web Components polyfills must be installed.
+      </p>
+    </header>
+
     <ol class="hxList">
       <li>
         Install <code>@webcomponents/webcomponentsjs</code> via one of the methods shown below.
@@ -97,11 +105,13 @@ title: Getting Started with HelixUI
       </li>
       <li>Proceed to "Step 3: Choose a Layout".</li>
     </ol>
+
     <p class="hxSubBody hxSubdued">
       <hx-icon type="info-circle"></hx-icon>
       Version 2.x (or later) is recommended, because it is more efficient
       in loading required polyfill bundles.
     </p>
+
     <hx-tabset class="beta-hxBound">
       <hx-tablist>
         <hx-tab>NPM</hx-tab>
@@ -151,14 +161,21 @@ title: Getting Started with HelixUI
         </hx-tabpanel>
       </hx-tabcontent>
     </hx-tabset>
-    <p class="hxSubdued hxSubBody">
-      <hx-icon type="info-circle"></hx-icon>
-      Visit the <a href="guides/polyfills">Polyfills</a> guide for more details.
-    </p>
+
+    <footer>
+      <p class="hxSubdued hxSubBody">
+        <hx-icon type="info-circle"></hx-icon>
+        Visit the <a href="guides/polyfills">Polyfills</a> guide for more details.
+      </p>
+    </footer>
   </section>
 
   <section>
-    <h2 id="step-3">Step 3: Choose a Layout</h2>
+    <header>
+      <h2 id="step-3">Step 3: Choose a Layout</h2>
+      {# TODO: add section description #}
+    </header>
+
     <ol class="hxList">
       <li>
         Choose one of the layouts shown below.
@@ -170,11 +187,13 @@ title: Getting Started with HelixUI
         Modify the template markup to conform to your application's file structure.
       </li>
     </ol>
+
     <p class="hxSubdued hxSubBody">
       <hx-icon type="info-circle"></hx-icon>
       Visit the <a href="components/layouts">Layouts</a> component
       documentation for customization details.
     </p>
+
     <hx-tabset class="beta-hxBound">
       <hx-tablist>
         <hx-tab>Vertical Layout</hx-tab>
@@ -241,12 +260,15 @@ title: Getting Started with HelixUI
   </section>
 
   <section><!-- Create Content -->
-    <h2 id="step-4">Step 4: Add Content</h2>
-    <p>
-      Add content and interactivity to your application using components.
-      Documentation for a component contains interactive demos and details
-      about various interaction patterns.
-    </p>
+    <header>
+      <h2 id="step-4">Step 4: Add Content</h2>
+      <p>
+        Add content and interactivity to your application using components.
+        Documentation for a component contains interactive demos and details
+        about various interaction patterns.
+      </p>
+    </header>
+
     <ol class="hxList">
       <li>Choose a component from the navigation on the left.</li>
       <li>Check the "See Also" section on the component page for more information.</li>

--- a/docs/guides/polyfills/index.html
+++ b/docs/guides/polyfills/index.html
@@ -2,6 +2,7 @@
 title: Polyfills
 ---
 {% extends 'guide.njk' %}
+
 {% macro nativeTo(api, browser) %}
   {% if api.missing and not api.missing.includes(browser) %}
     <hx-icon class="native-support" type="checkmark"></hx-icon>
@@ -9,10 +10,15 @@ title: Polyfills
     <hx-icon class="polyfill-needed" type="times"></hx-icon>
   {% endif %}
 {% endmacro %}
+
 {% block content %}
   <section>
-    <h2 id="included-polyfills">Included Polyfills</h2>
-    <p class="comfortable">
+    <header>
+      <h2 id="included-polyfills">Included Polyfills</h2>
+      {# TODO: add section description #}
+    </header>
+
+    <p>
       The table below lists the polyfilled JavaScript APIs required for HelixUI to
       function.  Native support for each API is shown in columns corresponding to
       each of the <a href="guides/faq/#supported-browsers">supported browsers</a>.
@@ -21,6 +27,7 @@ title: Polyfills
     </p>
 
     <table class="hxTable hxTable--condensed">
+      {# TODO: add table caption #}
       <thead>
         <tr>
           <th>JavaScript API</th>
@@ -46,21 +53,28 @@ title: Polyfills
         {% endfor %}
       </tbody>
     </table>
-    <p class="hxSubdued hxSubBody">
-      <hx-icon type="info-circle"></hx-icon>
-      Native support is checked against the latest release of each browser.
-    </p>
+
+    <footer>
+      <p class="hxSubdued hxSubBody">
+        <hx-icon type="info-circle"></hx-icon>
+        Native support is checked against the latest release of each browser.
+      </p>
+    </footer>
   </section>
 
   <section>
-    <h2 id="additional-polyfills">Additional Polyfills</h2>
-    <p>
-      If your application requires polyfills beyond those listed above, they will
-      need to be added separately.
-    </p>
+    <header>
+      <h2 id="additional-polyfills">Additional Polyfills</h2>
+      <p>
+        If your application requires polyfills beyond those listed above, they will
+        need to be added separately.
+      </p>
+    </header>
+
     <p>
       Access the following resources to find polyfills.
     </p>
+
     <ul class="hxList">
       <li>
         <a href="https://developer.mozilla.org">MDN documentation</a>

--- a/docs/guides/react-compatibility/index.html
+++ b/docs/guides/react-compatibility/index.html
@@ -2,52 +2,61 @@
 title: React Compatibility
 ---
 {% extends 'guide.njk' %}
+
 {% block content %}
   <section>
-    <h2 id="significant-white-space">Significant White Space</h2>
-    <p class="comfortable">
-      Similar to vanilla <code>&lt;span&gt;</code> elements, inline elements
-      defined in HelixUI may rely on significant white space surrounding the
-      tag in the HTML.
-    </p>
+    <header>
+      <h2 id="significant-white-space">Significant White Space</h2>
+      <p>
+        Similar to vanilla <code>&lt;span&gt;</code> elements, inline elements
+        defined in HelixUI may rely on significant white space surrounding the
+        tag in the HTML markup.
+      </p>
+    </header>
 
-    <br />
+    <section>
+      <header>
+        <h3>Problem</h3>
+        <p>
+          JSX has been found to remove significant white space in certain scenarios
+          (see demo below).
+        </p>
+      </header>
 
-    <h3>Problem</h3>
-    <p class="comfortable">
-      JSX has been found to remove significant white space in certain scenarios
-      (see demo below).
-    </p>
-    <figure class="hxFigure">
-      <iframe
-        allowfullscreen="true"
-        allowtransparency="true"
-        frameborder="no"
-        scrolling="no"
-        src="//codepen.io/HelixUI/embed/jpVYLQ/?height=265&theme-id=0&default-tab=js,result&embed-version=2"
-        title="Demo - JSX Collapsing Significant White Space"
-      >
-        See the Pen <a href="https://codepen.io/HelixUI/pen/jpVYLQ/">Demo - JSX Collapsing Significant White Space</a>
-        by HelixUI (<a href="https://codepen.io/HelixUI">@HelixUI</a>)
-        on <a href="https://codepen.io">CodePen</a>.
-      </iframe>
-      <figcaption>Demonstration of JSX Collapsing White Space</figcaption>
-    </figure>
+      <figure class="hxFigure">
+        <iframe
+          allowfullscreen="true"
+          allowtransparency="true"
+          frameborder="no"
+          scrolling="no"
+          src="//codepen.io/HelixUI/embed/jpVYLQ/?height=265&theme-id=0&default-tab=js,result&embed-version=2"
+          title="Demo - JSX Collapsing Significant White Space"
+        >
+          See the Pen <a href="https://codepen.io/HelixUI/pen/jpVYLQ/">Demo - JSX Collapsing Significant White Space</a>
+          by HelixUI (<a href="https://codepen.io/HelixUI">@HelixUI</a>)
+          on <a href="https://codepen.io">CodePen</a>.
+        </iframe>
+        <figcaption>Demonstration of JSX Collapsing White Space</figcaption>
+      </figure>
+    </section>
 
-    <br />
+    <section>
+      <header>
+        <h3>Solution</h3>
+        <p>
+          If you have encountered one of the scenarios demonstrated above, there are
+          two strategies available to correct it.
+        </p>
+      </header>
 
-    <h3>Solution</h3>
-    <p class="comfortable">
-      If you have encountered one of the scenarios demonstrated above, there are
-      two strategies available to correct it.
-    </p>
-    <ol class="hxList">
-      <li>
-        Rearrange your JSX markup so that it retains the needed white space.
-      </li>
-      <li>
-        Add a literal white space text node (<code>{' '}</code>) where it is needed.
-      </li>
-    </ol>
+      <ol class="hxList">
+        <li>
+          Rearrange your JSX markup so that it retains the needed white space.
+        </li>
+        <li>
+          Add a literal white space text node (<code>{' '}</code>) where it is needed.
+        </li>
+      </ol>
+    </section>
   </section>
 {% endblock %}


### PR DESCRIPTION
- move page description into page_header (if it makes sense)
- removed usage of `p.comfortable` styling
- add TODO comments to mark tasks for future updates
- update markup to be more semantic

JIRA: n/a

### LGTM's
- [x] Dev LGTM
- [x] Zoom LGTM
