### PR TITLE
feat(radio): add basic demo and enabled-focus-invalid tests

### DIFF
--- a/docs/components/radio/index.html
+++ b/docs/components/radio/index.html
@@ -20,6 +20,81 @@ also:
       {# TODO: add section description #}
     </header>
 
+    <div class="example" id="vue-radioBasicDemo" v-cloak>
+      <header>
+        <form class="beta-hxForm">
+          <hx-text-control>
+            <input
+              id="radLabel"
+              type="text"
+              v-model="radioLabel"
+            />
+            <label for="radLabel">
+              Radio Label
+            </label>
+          </hx-text-control>
+
+          <fieldset>
+            <legend class="beta-hxFieldName">Options</legend>
+            <hx-checkbox-control>
+              <input id="chkIsRadChecked" type="checkbox" v-model="isChecked" />
+              <label for="chkIsRadChecked">
+                <hx-checkbox></hx-checkbox>
+                Checked
+              </label>
+            </hx-checkbox-control>
+            <hx-checkbox-control>
+              <input id="chkIsRadDisabled" type="checkbox" v-model="isDisabled" />
+              <label for="chkIsRadDisabled">
+                <hx-checkbox></hx-checkbox>
+                Disabled
+              </label>
+            </hx-checkbox-control>
+            <hx-checkbox-control>
+              <input id="chkIsRadRequired" type="checkbox" v-model="isRequired" />
+              <label for="chkIsRadRequired">
+                <hx-checkbox></hx-checkbox>
+                Required
+              </label>
+            </hx-checkbox-control>
+          </fieldset>
+        </form>
+      </header>
+
+      <div>
+        <hx-radio-control>
+          <input
+            type="radio"
+            id="radBasicDemo"
+            :checked="isChecked"
+            :disabled="isDisabled"
+            :required="isRequired"
+          />
+          <label for="radBasicDemo">
+            <hx-radio></hx-radio>
+            {% raw %}{{radioLabel}}{% endraw %}
+          </label>
+        </hx-radio-control>
+      </div>
+
+      <footer>
+        <pre><code v-text="snippet"></code></pre>
+      </footer>
+    </div>
+    <p class="hxSubdued hxSubBody">
+      <hx-icon type="info-circle"></hx-icon>
+      Webkit-based browsers (e.g., Chrome, Safari, etc.) do not match the
+      <code>:required</code> CSS psuedo-class to radios in a single-item
+      radio group.
+    </p>
+  </section>
+
+  <section>
+    <header>
+      <h2 id="radio-set">Radio Set</h2>
+      {# TODO: add section description #}
+    </header>
+
     <div class="example" id="vue-radioDemo" v-cloak>
       <header>
         <form class="beta-hxForm">
@@ -100,14 +175,5 @@ also:
         <pre><code v-text="snippet"></code></pre>
       </footer>
     </div>
-
-    <footer>
-      <p class="hxSubdued hxSubBody">
-        <hx-icon type="info-circle"></hx-icon>
-        Webkit-based browsers (e.g., Chrome, Safari, etc.) do not match the
-        <code>:required</code> CSS psuedo-class to radios in a single-item
-        radio group.
-      </p>
-    </footer>
   </section>
 {% endblock %}

--- a/docs/components/radio/radio-basic-demo.js
+++ b/docs/components/radio/radio-basic-demo.js
@@ -1,0 +1,32 @@
+import Util from '../../_util';
+
+if (document.getElementById('vue-radioBasicDemo')) {
+    new Vue({
+        el: '#vue-radioBasicDemo',
+        data: {
+            isChecked: false,
+            isDisabled: false,
+            isRequired: false,
+            radioLabel: 'Radio Label',
+        },
+        computed: {
+            snippet: function () {
+                return Util.snippet(`
+                    <hx-radio-control>
+                      <input
+                        type="radio"
+                        id="radBasicDemo"
+                        ${this.isChecked ? 'checked' : ''}
+                        ${this.isDisabled ? 'disabled' : ''}
+                        ${this.isRequired ? 'required' : ''}
+                      />
+                      <label for="radBasicDemo">
+                        <hx-radio></hx-radio>
+                        ${this.radioLabel}
+                      </label>
+                    <hx-radio-control>
+                `);
+            },
+        },
+    });
+}

--- a/docs/components/radio/test.html
+++ b/docs/components/radio/test.html
@@ -7,7 +7,18 @@ crumbs:
 {% extends 'test.njk' %}
 {% set contentClasses = 'radio-spec' %}
 
-{% macro radio(id='', name='', isDirty=false, isRequired=false, isChecked=false, isDisabled=false, isFocused=false, isHovered=false, isValid=true) %}
+{% macro radio(
+    id='',
+    name='',
+    state='',
+    isChecked=false,
+    isDirty=false,
+    isDisabled=false,
+    isFocused=false,
+    isHovered=false,
+    isRequired=false,
+    isValid=true)
+%}
   {% set isPristine = not isDirty %}
 
   {% set idAttr -%}
@@ -42,7 +53,13 @@ crumbs:
     <label for="{{idAttr | trim}}">
       <hx-radio></hx-radio>
       {{ id if id !=='' }}-
-      {{ 'Dirty' if isDirty else 'Pristine' }},
+      {% if state === 'dirty' %}
+        Dirty,
+      {% elif state === 'cssInvalid' %}
+        Visually Invalid,
+      {% else %}
+        Pristine,
+      {% endif %}
       {{ 'Required' if isRequired else 'Optional' }},
       {{ 'Disabled' if isDisabled else 'Enabled' }},
       {{ 'Valid' if isValid else 'Invalid' }},
@@ -57,10 +74,19 @@ crumbs:
   </hx-radio-control>
 {% endmacro %}
 
-{% macro radioSet(id='', className='', isDirty=false, isDisabled=false, isFocused=false, isHovered=false, isRequired=false, isValid=true) %}
-  {% set focused2 = (isFocused and isValid) %}
+{% macro radioSet(
+    state='',
+    className='',
+    isDirty=false,
+    isDisabled=false,
+    isFocused=false,
+    isHovered=false,
+    isRequired=false,
+    isValid=true)
+%}
+
   {% set name -%}radioSet-
-    {{- id -}}
+    {{- state -}}
     {{- 'Required' if isRequired else 'Optional' -}}
     {{- 'Disabled' if isDisabled else 'Enabled' -}}
     {{- 'Valid' if isValid else 'Invalid' -}}
@@ -72,15 +98,38 @@ crumbs:
     {% if isDirty %}hx-dirty {% endif %}
     {% if className !== '' %}class="{{className}}" {% endif %}
   >
-    {{ radio(id='Radio1', name=name, isDirty=isDirty, isHovered=isHovered, isDisabled=isDisabled, isRequired=isRequired, isValid=isValid, isChecked=false) }}
-    {{ radio(id='Radio2', name=name, isDirty=isDirty, isHovered=isHovered, isDisabled=isDisabled, isRequired=isRequired, isValid=isValid, isChecked=isValid, isFocused=focused2) }}
+    {{ radio(
+        id='Radio1',
+        className=className,
+        name=name,
+        state=state,
+        isChecked=false,
+        isDisabled=isDisabled,
+        isDirty=isDirty,
+        isHovered=isHovered,
+        isRequired=isRequired,
+        isValid=isValid)
+    }}
+    {{ radio(
+        id='Radio2',
+        className=className,
+        name=name,
+        state=state,
+        isChecked=isValid,
+        isDirty=isDirty,
+        isDisabled=isDisabled,
+        isFocused=isFocused,
+        isHovered=isHovered,
+        isRequired=isRequired,
+        isValid=isValid)
+    }}
   </hx-radio-set>
 {% endmacro %}
 
 {% block content %}
   <section>
     <header>
-      <h2 id="test-pristine">Pristine</h2>
+      <h2 id="test-pristine-state">Pristine</h2>
       <code>&lt;hx-radio-set&gt;</code>
     </header>
 
@@ -103,7 +152,7 @@ crumbs:
           </tr>
           <tr>
             <td>{{radioSet('pristine', isFocused=true)}}</td>
-            <td>N/A</td>
+            <td>{{radioSet('pristine', isFocused=true, isValid=false)}}</td>
           </tr>
           <tr>
             <td>{{radioSet('pristine', isHovered=true)}}</td>
@@ -159,7 +208,7 @@ crumbs:
           </tr>
           <tr>
             <td>{{radioSet('pristine', isFocused=true, isRequired=true)}}</td>
-            <td>N/A</td>
+            <td>{{radioSet('pristine', isFocused=true, isRequired=true, isValid=false)}}</td>
           </tr>
           <tr>
             <td>{{radioSet('pristine', isHovered=true, isRequired=true)}}</td>
@@ -199,7 +248,7 @@ crumbs:
 
   <section>
     <header>
-      <h2 id="test-dirty">Dirty</h2>
+      <h2 id="test-dirty-state">Dirty</h2>
       <code>&lt;hx-radio-set hx-dirty&gt;</code>
     </header>
 
@@ -222,7 +271,7 @@ crumbs:
           </tr>
           <tr>
             <td>{{radioSet('dirty', isDirty=true, isFocused=true)}}</td>
-            <td>N/A</td>
+            <td>{{radioSet('dirty', isDirty=true, isFocused=true, isValid=false)}}</td>
           </tr>
           <tr>
             <td>{{radioSet('dirty', isDirty=true, isHovered=true)}}</td>
@@ -278,7 +327,7 @@ crumbs:
           </tr>
           <tr>
             <td>{{radioSet('dirty', isDirty=true, isFocused=true, isRequired=true)}}</td>
-            <td>N/A</td>
+            <td>{{radioSet('dirty', isDirty=true, isFocused=true, isRequired=true, isValid=false)}}</td>
           </tr>
           <tr>
             <td>{{radioSet('dirty', isDirty=true, isHovered=true, isRequired=true)}}</td>
@@ -318,7 +367,7 @@ crumbs:
 
   <section>
     <header>
-      <h2 id="test-visually-invalid">Visually Invalid</h2>
+      <h2 id="test-visually-invalid-state">Visually Invalid</h2>
       <code>&lt;hx-radio-set class="hxInvalid"&gt;</code>
     </header>
 
@@ -341,7 +390,7 @@ crumbs:
           </tr>
           <tr>
             <td>{{radioSet('cssInvalid', className='hxInvalid', isFocused=true)}}</td>
-            <td>N/A</td>
+            <td>{{radioSet('cssInvalid', className='hxInvalid', isFocused=true, isValid=false)}}</td>
           </tr>
           <tr>
             <td>{{radioSet('cssInvalid', className='hxInvalid', isHovered=true)}}</td>
@@ -397,7 +446,7 @@ crumbs:
           </tr>
           <tr>
             <td>{{radioSet('cssInvalid', className='hxInvalid', isFocused=true, isRequired=true)}}</td>
-            <td>N/A</td>
+            <td>{{radioSet('cssInvalid', className='hxInvalid', isFocused=true, isRequired=true, isValid=false)}}</td>
           </tr>
           <tr>
             <td>{{radioSet('cssInvalid', className='hxInvalid', isHovered=true, isRequired=true)}}</td>

--- a/docs/docs.js
+++ b/docs/docs.js
@@ -19,6 +19,7 @@ import './components/modal/modal-demo';
 import './components/panel/panel-demo';
 import './components/pill/pill-demo';
 import './components/popover/popover-demo';
+import './components/radio/radio-basic-demo';
 import './components/radio/radio-demo';
 import './components/reveal/reveal-demo';
 import './components/search/search-demo';


### PR DESCRIPTION
* add a basic radio demo:

```html
<hx-radio-set>
  <input id="radBasicDemo" type="radio" />
  <label for="radBasicDemo">
    <hx-radio></hx-radio>
    Radio Label
  </label>
</hx-radio-set>
```
* add `Visually Invalid` label for `class="hxInvalid"` styles

* update Test Page to include tests for:
  - Pristine State:
    * `Optional, Enabled, Focused, Invalid`
    * `Required, Enabled, Focused, Invalid`
  - Dirty State:
    * `Optional, Enabled, Focused, Invalid`
    * `Required, Enabled, Focused, Invalid`
  - Visually Invalid State:
    * `Optional, Enabled, Focused, Invalid`
    * `Required, Enabled, Focused, Invalid`

#### JIRA: SURF-1635

### LGTM's
- [x] Dev LGTM
- [x] Zoom LGTM
