### PR TITLE
fix(radios): add missing demo page <hx-radio-set> elements

### DIFF
--- a/docs/components/box/index.html
+++ b/docs/components/box/index.html
@@ -189,19 +189,21 @@ also:
         <form class="beta-hxForm">
           <fieldset>
             <legend class="beta-hxFieldName">Scroll Direction</legend>
-            <hx-radio-control v-for="(_direction, idx) in directions">
-              <input
-                :id="'radDirection' + idx"
-                :value="_direction"
-                name="direction"
-                type="radio"
-                v-model="direction"
-              />
-              <label :for="'radDirection' + idx">
-                <hx-radio></hx-radio>
-                {% raw %}{{_direction}}{% endraw %}
-              </label>
-            </hx-radio-control>
+            <hx-radio-set>
+              <hx-radio-control v-for="(_direction, idx) in directions">
+                <input
+                  :id="'radDirection' + idx"
+                  :value="_direction"
+                  name="direction"
+                  type="radio"
+                  v-model="direction"
+                />
+                <label :for="'radDirection' + idx">
+                  <hx-radio></hx-radio>
+                  {% raw %}{{_direction}}{% endraw %}
+                </label>
+              </hx-radio-control>
+            </hx-radio-set>
           </fieldset>
 
           <fieldset>

--- a/docs/components/button/index.html
+++ b/docs/components/button/index.html
@@ -44,38 +44,42 @@ also:
         <form class="beta-hxForm">
           <fieldset>
             <legend class="beta-hxFieldName">Variant</legend>
-            <hx-radio-control v-for="(_variant, idx) in variants">
-              <input
-                :id="'radBasicVariant' + idx"
-                :value="_variant"
-                name="variant"
-                type="radio"
-                v-model="variant"
-              />
-              <label :for="'radBasicVariant' + idx">
-                <hx-radio></hx-radio>
-                {% raw %}{{_variant.label}}{% endraw %}
-              </label>
-              <p v-if="_variant.default">(default)</p>
-            </hx-radio-control>
+            <hx-radio-set>
+              <hx-radio-control v-for="(_variant, idx) in variants">
+                <input
+                  :id="'radBasicVariant' + idx"
+                  :value="_variant"
+                  name="variant"
+                  type="radio"
+                  v-model="variant"
+                />
+                <label :for="'radBasicVariant' + idx">
+                  <hx-radio></hx-radio>
+                  {% raw %}{{_variant.label}}{% endraw %}
+                </label>
+                <p v-if="_variant.default">(default)</p>
+              </hx-radio-control>
+            </hx-radio-set>
           </fieldset>
 
           <fieldset>
             <legend class="beta-hxFieldName">Size</legend>
-            <hx-radio-control v-for="(_size, idx) in sizes">
-              <input
-                :id="'radBasicSize' + idx"
-                :value="_size"
-                name="size"
-                type="radio"
-                v-model="size"
-              />
-              <label :for="'radBasicSize' + idx">
-                <hx-radio></hx-radio>
-                {% raw %}{{_size.label}}{% endraw %}
-              </label>
-              <p v-if="_size.default">(default)</p>
-            </hx-radio-control>
+            <hx-radio-set>
+              <hx-radio-control v-for="(_size, idx) in sizes">
+                <input
+                  :id="'radBasicSize' + idx"
+                  :value="_size"
+                  name="size"
+                  type="radio"
+                  v-model="size"
+                />
+                <label :for="'radBasicSize' + idx">
+                  <hx-radio></hx-radio>
+                  {% raw %}{{_size.label}}{% endraw %}
+                </label>
+                <p v-if="_size.default">(default)</p>
+              </hx-radio-control>
+            </hx-radio-set>
           </fieldset>
         </form>
       </header>
@@ -151,38 +155,42 @@ also:
         <form class="beta-hxForm">
           <fieldset>
             <legend class="beta-hxFieldName">Variant</legend>
-            <hx-radio-control v-for="(_variant, idx) in variants">
-              <input
-                :id="'radGroupVariant' + idx"
-                :value="_variant"
-                name="variant"
-                type="radio"
-                v-model="variant"
-              />
-              <label :for="'radGroupVariant' + idx">
-                <hx-radio></hx-radio>
-                {% raw %}{{_variant.label}}{% endraw %}
-              </label>
-              <p v-if="_variant.default">(default)</p>
-            </hx-radio-control>
+            <hx-radio-set>
+              <hx-radio-control v-for="(_variant, idx) in variants">
+                <input
+                  :id="'radGroupVariant' + idx"
+                  :value="_variant"
+                  name="variant"
+                  type="radio"
+                  v-model="variant"
+                />
+                <label :for="'radGroupVariant' + idx">
+                  <hx-radio></hx-radio>
+                  {% raw %}{{_variant.label}}{% endraw %}
+                </label>
+                <p v-if="_variant.default">(default)</p>
+              </hx-radio-control>
+            </hx-radio-set>
           </fieldset>
 
           <fieldset>
             <legend class="beta-hxFieldName">Size</legend>
-            <hx-radio-control v-for="(_size, idx) in sizes">
-              <input
-                :id="'radGroupSize' + idx"
-                :value="_size"
-                name="size"
-                type="radio"
-                v-model="size"
-              />
-              <label :for="'radGroupSize' + idx">
-                <hx-radio></hx-radio>
-                {% raw %}{{_size.label}}{% endraw %}
-              </label>
-              <p v-if="_size.default">(default)</p>
-            </hx-radio-control>
+            <hx-radio-set>
+              <hx-radio-control v-for="(_size, idx) in sizes">
+                <input
+                  :id="'radGroupSize' + idx"
+                  :value="_size"
+                  name="size"
+                  type="radio"
+                  v-model="size"
+                />
+                <label :for="'radGroupSize' + idx">
+                  <hx-radio></hx-radio>
+                  {% raw %}{{_size.label}}{% endraw %}
+                </label>
+                <p v-if="_size.default">(default)</p>
+              </hx-radio-control>
+            </hx-radio-set>
           </fieldset>
         </form>
       </header>

--- a/docs/components/file/index.html
+++ b/docs/components/file/index.html
@@ -106,37 +106,41 @@ also:
 
           <fieldset>
             <legend class="beta-hxFieldName">Button Variant</legend>
-            <hx-radio-control v-for="(_variant, idx) in variants">
-              <input
-                :id="'radSelectorVariant' + idx"
-                :value="_variant"
-                name="variant"
-                type="radio"
-                v-model="variant"
-              />
-              <label :for="'radSelectorVariant' + idx">
-                <hx-radio></hx-radio>
-                {% raw %}{{_variant.label}}{% endraw %}
-              </label>
-              <p v-if="_variant.default">(default)</p>
-            </hx-radio-control>
+            <hx-radio-set>
+              <hx-radio-control v-for="(_variant, idx) in variants">
+                <input
+                  :id="'radSelectorVariant' + idx"
+                  :value="_variant"
+                  name="variant"
+                  type="radio"
+                  v-model="variant"
+                />
+                <label :for="'radSelectorVariant' + idx">
+                  <hx-radio></hx-radio>
+                  {% raw %}{{_variant.label}}{% endraw %}
+                </label>
+                <p v-if="_variant.default">(default)</p>
+              </hx-radio-control>
+            </hx-radio-set>
           </fieldset>
 
           <fieldset>
             <legend class="beta-hxFieldName">Icon</legend>
-            <hx-radio-control v-for="(_icon, idx) in icons">
-              <input
-                :id="'radSelectorIcon' + idx"
-                :value="_icon"
-                name="icon"
-                type="radio"
-                v-model="icon"
-              />
-              <label :for="'radSelectorIcon' + idx">
-                <hx-radio></hx-radio>
-                {% raw %}{{_icon}}{% endraw %}
-              </label>
-            </hx-radio-control>
+            <hx-radio-set>
+              <hx-radio-control v-for="(_icon, idx) in icons">
+                <input
+                  :id="'radSelectorIcon' + idx"
+                  :value="_icon"
+                  name="icon"
+                  type="radio"
+                  v-model="icon"
+                />
+                <label :for="'radSelectorIcon' + idx">
+                  <hx-radio></hx-radio>
+                  {% raw %}{{_icon}}{% endraw %}
+                </label>
+              </hx-radio-control>
+            </hx-radio-set>
           </fieldset>
 
           <fieldset>
@@ -236,47 +240,49 @@ also:
 
           <fieldset>
             <legend class="beta-hxFieldName">State</legend>
-            <hx-radio-control>
-              <input
-                id="radTileDownloadable"
-                name="file-state"
-                type="radio"
-                v-model="state"
-                value="downloadable"
-              />
-              <label for="radTileDownloadable">
-                <hx-radio></hx-radio>
-                Downloadable
-              </label>
-            </hx-radio-control>
+            <hx-radio-set>
+              <hx-radio-control>
+                <input
+                  id="radTileDownloadable"
+                  name="file-state"
+                  type="radio"
+                  v-model="state"
+                  value="downloadable"
+                />
+                <label for="radTileDownloadable">
+                  <hx-radio></hx-radio>
+                  Downloadable
+                </label>
+              </hx-radio-control>
 
-            <hx-radio-control>
-              <input
-                id="radTileLoading"
-                name="file-state"
-                type="radio"
-                v-model="state"
-                value="loading"
-              />
-              <label for="radTileLoading">
-                <hx-radio></hx-radio>
-                Loading
-              </label>
-            </hx-radio-control>
+              <hx-radio-control>
+                <input
+                  id="radTileLoading"
+                  name="file-state"
+                  type="radio"
+                  v-model="state"
+                  value="loading"
+                />
+                <label for="radTileLoading">
+                  <hx-radio></hx-radio>
+                  Loading
+                </label>
+              </hx-radio-control>
 
-            <hx-radio-control>
-              <input
-                id="radTileInvalid"
-                name="file-state"
-                type="radio"
-                v-model="state"
-                value="invalid"
-              />
-              <label for="radTileInvalid">
-                <hx-radio></hx-radio>
-                Invalid
-              </label>
-            </hx-radio-control>
+              <hx-radio-control>
+                <input
+                  id="radTileInvalid"
+                  name="file-state"
+                  type="radio"
+                  v-model="state"
+                  value="invalid"
+                />
+                <label for="radTileInvalid">
+                  <hx-radio></hx-radio>
+                  Invalid
+                </label>
+              </hx-radio-control>
+            </hx-radio-set>
           </fieldset>
 
           <template v-if="isDownloadable">

--- a/docs/components/modal/index.html
+++ b/docs/components/modal/index.html
@@ -27,20 +27,22 @@ also:
         <form class="beta-hxForm">
           <fieldset>
             <legend class="beta-hxFieldName">Size</legend>
-            <hx-radio-control v-for="(_size, idx) in sizes">
-              <input
-                :id="'radSize' + idx"
-                :value="_size"
-                name="size"
-                type="radio"
-                v-model="size"
-              />
-              <label :for="'radSize' + idx">
-                <hx-radio></hx-radio>
-                {% raw %}{{_size.label}}{% endraw %}
-              </label>
-              <p v-if="_size.default">(default)</p>
-            </hx-radio-control>
+            <hx-radio-set>
+              <hx-radio-control v-for="(_size, idx) in sizes">
+                <input
+                  :id="'radSize' + idx"
+                  :value="_size"
+                  name="size"
+                  type="radio"
+                  v-model="size"
+                />
+                <label :for="'radSize' + idx">
+                  <hx-radio></hx-radio>
+                  {% raw %}{{_size.label}}{% endraw %}
+                </label>
+                <p v-if="_size.default">(default)</p>
+              </hx-radio-control>
+            </hx-radio-set>
           </fieldset>
 
           <fieldset>

--- a/docs/components/table/index.html
+++ b/docs/components/table/index.html
@@ -20,33 +20,35 @@ minver: 0.1.7
         <form class="beta-hxForm">
           <fieldset>
             <legend class="beta-hxFieldName">Data Density</legend>
-            <hx-radio-control>
-              <input
-                id="radNormal"
-                name="density"
-                type="radio"
-                v-model="isCondensed"
-                :value="false"
-              />
-              <label for="radNormal">
-                <hx-radio></hx-radio>
-                Normal
-              </label>
-            </hx-radio-control>
+            <hx-radio-set>
+              <hx-radio-control>
+                <input
+                  :value="false"
+                  id="radNormal"
+                  name="density"
+                  type="radio"
+                  v-model="isCondensed"
+                />
+                <label for="radNormal">
+                  <hx-radio></hx-radio>
+                  Normal
+                </label>
+              </hx-radio-control>
 
-            <hx-radio-control>
-              <input
-                id="radCondensed"
-                name="density"
-                type="radio"
-                v-model="isCondensed"
-                :value="true"
-              />
-              <label for="radCondensed">
-                <hx-radio></hx-radio>
-                Condensed
-              </label>
-            </hx-radio-control>
+              <hx-radio-control>
+                <input
+                  :value="true"
+                  id="radCondensed"
+                  name="density"
+                  type="radio"
+                  v-model="isCondensed"
+                />
+                <label for="radCondensed">
+                  <hx-radio></hx-radio>
+                  Condensed
+                </label>
+              </hx-radio-control>
+            </hx-radio-set>
           </fieldset>
 
           <fieldset>

--- a/src/helix-ui/styles/components/radios.less
+++ b/src/helix-ui/styles/components/radios.less
@@ -13,6 +13,18 @@ hx-radio {
 
 hx-radio-set {
   display: block;
+
+  > * {
+    margin: 0.25rem 0; // FIXME: solve with spacing system
+
+    &:first-child {
+      margin-top: 0; // FIXME: solve with spacing system
+    }
+
+    &:last-child {
+      margin-bottom: 0; // FIXME: solve with spacing system
+    }
+  }
 }
 
 // LAYOUT GEOMETRY


### PR DESCRIPTION
### Free Friday

* add missing `<hx-radio-set>` elements to the following demo pages:
  * box
  * button
  * file
  * modal
  * table

### LGTM's
- [x] Dev LGTM
- [x] Zoom LGTM
