### PR TITLE
fix(alignment): correct "smart" repositioning alignment

### DIFF
--- a/docs/_templates/no-frame.njk
+++ b/docs/_templates/no-frame.njk
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="{{site.language}}">
+<head>
+  <title>{% if page.title %}{{page.title}} - {% endif %}{{site.title}}</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <base href="{{site.baseHref}}">
+
+  <link rel="shortcut icon" href="images/favicon.png">
+
+  {# HelixUI Styles (generated from src/) #}
+  <link rel="stylesheet" href="dist/styles/helix-ui.css">
+  {# Documentation Styles (generated from docs/) #}
+  <link rel="stylesheet" href="docs.css">
+
+  <!-- Converts ES5 custom element constructor functions to ES6 classes -->
+  <script src="vendor/custom-elements-es5-adapter.js"></script>
+
+  <!-- loader appends polyfills, if needed -->
+  <script src="vendor/webcomponents-loader.js"></script>
+</head>
+<body>
+  <main role="main" class="{{mainClass}} {{contentClasses}}">
+    {% block content %}
+      {# page content goes here #}
+    {% endblock %}
+  </main>
+
+  {# Vue for Interactive Demos #}
+  <script src="https://unpkg.com/vue@2.5.16/dist/vue.js"></script>
+  {# HelixUI Behavior (generated from src/) #}
+  <script src="dist/scripts/helix-ui.browser.js"></script>
+  {# Documentation Behavior (generated from docs/) #}
+  <script src="docs.js"></script>
+</body>
+</html>

--- a/docs/components/menu/test-positioning.html
+++ b/docs/components/menu/test-positioning.html
@@ -1,0 +1,202 @@
+---
+title: Testing - Menu Positioning
+---
+{% extends 'no-frame.njk' %}
+{% set contentClasses = 'menu-positioning-spec' %}
+
+{% block content %}
+  <div id="target-center">Target</div>
+  <div id="target-quad1">Target</div>
+  <div id="target-quad2">Target</div>
+  <div id="target-quad3">Target</div>
+  <div id="target-quad4">Target</div>
+  <div id="target-topLeft">Target</div>
+  <div id="target-topRight">Target</div>
+  <div id="target-bottomRight">Target</div>
+  <div id="target-bottomLeft">Target</div>
+
+  <!-- CENTER TARGET -->
+  <hx-menu relative-to="target-center" position="top" open>
+    <section>
+      <header>"top" Menu</header>
+      <hx-menuitem>Action 1</hx-menuitem>
+      <hx-menuitem>Action 2</hx-menuitem>
+      <hx-menuitem>Action 3</hx-menuitem>
+    </section>
+  </hx-menu>
+  <hx-menu relative-to="target-center" position="left" open>
+    <section>
+      <header>"left" Menu</header>
+      <hx-menuitem>Action 1</hx-menuitem>
+      <hx-menuitem>Action 2</hx-menuitem>
+      <hx-menuitem>Action 3</hx-menuitem>
+    </section>
+  </hx-menu>
+  <hx-menu relative-to="target-center" position="right" open>
+    <section>
+      <header>"right" Menu</header>
+      <hx-menuitem>Action 1</hx-menuitem>
+      <hx-menuitem>Action 2</hx-menuitem>
+      <hx-menuitem>Action 3</hx-menuitem>
+    </section>
+  </hx-menu>
+  <hx-menu relative-to="target-center" position="bottom" open>
+    <section>
+      <header>"bottom" Menu</header>
+      <hx-menuitem>Action 1</hx-menuitem>
+      <hx-menuitem>Action 2</hx-menuitem>
+      <hx-menuitem>Action 3</hx-menuitem>
+    </section>
+  </hx-menu>
+
+  <!-- QUAD 1 TARGET -->
+  <hx-menu relative-to="target-quad1" position="right-start" open>
+    <section>
+      <header>"right-start" Menu</header>
+      <hx-menuitem>Action 1</hx-menuitem>
+      <hx-menuitem>Action 2</hx-menuitem>
+      <hx-menuitem>Action 3</hx-menuitem>
+    </section>
+  </hx-menu>
+  <hx-menu relative-to="target-quad1" position="top-end" open>
+    <section>
+      <header>"top-end" Menu</header>
+      <hx-menuitem>Action 1</hx-menuitem>
+      <hx-menuitem>Action 2</hx-menuitem>
+      <hx-menuitem>Action 3</hx-menuitem>
+    </section>
+  </hx-menu>
+
+  <!-- QUAD 2 TARGET -->
+  <hx-menu relative-to="target-quad2" position="right-end" open>
+    <section>
+      <header>"right-end" Menu</header>
+      <hx-menuitem>Action 1</hx-menuitem>
+      <hx-menuitem>Action 2</hx-menuitem>
+      <hx-menuitem>Action 3</hx-menuitem>
+    </section>
+  </hx-menu>
+  <hx-menu relative-to="target-quad2" position="bottom-end" open>
+    <section>
+      <header>"bottom-end" Menu</header>
+      <hx-menuitem>Action 1</hx-menuitem>
+      <hx-menuitem>Action 2</hx-menuitem>
+      <hx-menuitem>Action 3</hx-menuitem>
+    </section>
+  </hx-menu>
+
+  <!-- QUAD 3 TARGET -->
+  <hx-menu relative-to="target-quad3" position="left-end" open>
+    <section>
+      <header>"left-end" Menu</header>
+      <hx-menuitem>Action 1</hx-menuitem>
+      <hx-menuitem>Action 2</hx-menuitem>
+      <hx-menuitem>Action 3</hx-menuitem>
+    </section>
+  </hx-menu>
+  <hx-menu relative-to="target-quad3" position="bottom-start" open>
+    <section>
+      <header>"bottom-start" Menu</header>
+      <hx-menuitem>Action 1</hx-menuitem>
+      <hx-menuitem>Action 2</hx-menuitem>
+      <hx-menuitem>Action 3</hx-menuitem>
+    </section>
+  </hx-menu>
+
+  <!-- QUAD 4 TARGET -->
+  <hx-menu relative-to="target-quad4" position="left-start" open>
+    <section>
+      <header>"left-start" Menu</header>
+      <hx-menuitem>Action 1</hx-menuitem>
+      <hx-menuitem>Action 2</hx-menuitem>
+      <hx-menuitem>Action 3</hx-menuitem>
+    </section>
+  </hx-menu>
+  <hx-menu relative-to="target-quad4" position="top-start" open>
+    <section>
+      <header>"top-start" Menu</header>
+      <hx-menuitem>Action 1</hx-menuitem>
+      <hx-menuitem>Action 2</hx-menuitem>
+      <hx-menuitem>Action 3</hx-menuitem>
+    </section>
+  </hx-menu>
+
+
+  <!-- SMART REPOSITIONING -->
+  <!--
+    Intentionally positioned offscreen so that we can test if
+    repositioning logic is working.
+  -->
+
+  <!-- TOP RIGHT TARGET -->
+  <hx-menu relative-to="target-topRight" position="right-end" open>
+    <section>
+      <header>"right-end" Menu</header>
+      <hx-menuitem>Action 1</hx-menuitem>
+      <hx-menuitem>Action 2</hx-menuitem>
+      <hx-menuitem>Action 3</hx-menuitem>
+    </section>
+  </hx-menu>
+  <hx-menu relative-to="target-topRight" position="top-start" open>
+    <section>
+      <header>"top-start" Menu</header>
+      <hx-menuitem>Action 1</hx-menuitem>
+      <hx-menuitem>Action 2</hx-menuitem>
+      <hx-menuitem>Action 3</hx-menuitem>
+    </section>
+  </hx-menu>
+
+  <!-- BOTTOM RIGHT TARGET -->
+  <hx-menu relative-to="target-bottomRight" position="bottom-start" open>
+    <section>
+      <header>"bottom-start" Menu</header>
+      <hx-menuitem>Action 1</hx-menuitem>
+      <hx-menuitem>Action 2</hx-menuitem>
+      <hx-menuitem>Action 3</hx-menuitem>
+    </section>
+  </hx-menu>
+  <hx-menu relative-to="target-bottomRight" position="right-start" open>
+    <section>
+      <header>"right-start" Menu</header>
+      <hx-menuitem>Action 1</hx-menuitem>
+      <hx-menuitem>Action 2</hx-menuitem>
+      <hx-menuitem>Action 3</hx-menuitem>
+    </section>
+  </hx-menu>
+
+  <!-- BOTTOM LEFT TARGET -->
+  <hx-menu relative-to="target-bottomLeft" position="bottom-end" open>
+    <section>
+      <header>"bottom-end" Menu</header>
+      <hx-menuitem>Action 1</hx-menuitem>
+      <hx-menuitem>Action 2</hx-menuitem>
+      <hx-menuitem>Action 3</hx-menuitem>
+    </section>
+  </hx-menu>
+  <hx-menu relative-to="target-bottomLeft" position="left-start" open>
+    <section>
+      <header>"left-start" Menu</header>
+      <hx-menuitem>Action 1</hx-menuitem>
+      <hx-menuitem>Action 2</hx-menuitem>
+      <hx-menuitem>Action 3</hx-menuitem>
+    </section>
+  </hx-menu>
+
+  <!-- TOP LEFT TARGET -->
+  <hx-menu relative-to="target-topLeft" position="left-end" open>
+    <section>
+      <header>"left-end" Menu</header>
+      <hx-menuitem>Action 1</hx-menuitem>
+      <hx-menuitem>Action 2</hx-menuitem>
+      <hx-menuitem>Action 3</hx-menuitem>
+    </section>
+  </hx-menu>
+  <hx-menu relative-to="target-topLeft" position="top-end" open>
+    <section>
+      <header>"top-end" Menu</header>
+      <hx-menuitem>Action 1</hx-menuitem>
+      <hx-menuitem>Action 2</hx-menuitem>
+      <hx-menuitem>Action 3</hx-menuitem>
+    </section>
+  </hx-menu>
+{% endblock %}

--- a/docs/docs.less
+++ b/docs/docs.less
@@ -408,6 +408,7 @@ min-version {
 @import 'spec/drawer-spec';
 @import 'spec/dropdown-select-spec';
 @import 'spec/file-input-spec';
+@import 'spec/menu-positioning-spec';
 @import 'spec/panel-spec';
 @import 'spec/popover-spec';
 @import 'spec/radio-spec';

--- a/docs/styles/spec/menu-positioning-spec.less
+++ b/docs/styles/spec/menu-positioning-spec.less
@@ -1,0 +1,68 @@
+.menu-positioning-spec {
+  [id^="target"] {
+    align-items: center;
+    background-color: @gray-300;
+    display: flex;
+    height: 6rem;
+    justify-content: center;
+    position: fixed;
+    width: 6rem;
+  }
+
+  // vertical target alignment
+  [id$="quad1"],
+  [id$="quad4"] {
+    top: 33%;
+  }
+
+  [id$="quad2"],
+  [id$="quad3"] {
+    top: 67%;
+  }
+
+  // horizontal target alignment
+  [id$="quad1"],
+  [id$="quad2"] {
+    left: 67%;
+  }
+
+  [id$="quad3"],
+  [id$="quad4"] {
+    left: 33%;
+  }
+
+  #target-center,
+  #target-quad1,
+  #target-quad2,
+  #target-quad3,
+  #target-quad4 {
+    transform: translate(-50%, -50%);
+  }
+
+  #target-center {
+    height: 9rem;
+    left: 50%;
+    top: 50%;
+    width: 9rem;
+  }
+
+  #target-topLeft {
+    left: 0;
+    top: 0;
+  }
+
+  #target-topRight {
+    right: 0;
+    top: 0;
+  }
+
+  #target-bottomLeft {
+    bottom: 0;
+    left: 0;
+  }
+
+  #target-bottomRight {
+    bottom: 0;
+    right: 0;
+  }
+}

--- a/src/helix-ui/utils/alignment.js
+++ b/src/helix-ui/utils/alignment.js
@@ -233,43 +233,63 @@ export function normalizePosition (position) {
 export function optimizePositionForCollisions (position, collides) {
     let { xAlign, yAlign } = getAlignment(position);
 
-    // COLLIDE TOP
-    // 'top-*' -> 'bottom-*' (CHANGE)
-    // '{H}-top' -> '{H}-bottom' (CHANGE)
-    // 'bottom-*' -> 'bottom-*' (no change)
-    // '{H}-bottom' -> '{H}-bottom' (no change)
-    // '{H}-start|middle|end' -> '{H}-start|middle|end' (no change)
-    if (collides.top && yAlign === 'top') {
+    // ----- COLLIDE WITH TOP EDGE -----
+    // CHANGE
+    // - 'top-*'            -> 'bottom-*'
+    // - '(left|right)-top' -> '(left|right)-bottom'
+    // - '(left|right)-end' -> '(left|right)-start'
+    //
+    // IGNORE
+    // - 'bottom-*'
+    // - '{H}-bottom'
+    // - '{H}-start'
+    // - '{H}-middle'
+    if (collides.top && yAlign.match(/top|end/)) {
         position = invertPositionVertically(position);
     }
 
-    // COLLIDE BOTTOM
-    // 'bottom-*' -> 'top-*' (CHANGE)
-    // '{H}-bottom' -> '{H}-top' (CHANGE)
-    // 'top-*' -> 'top-*' (no change)
-    // '{H}-top' -> '{H}-top' (no change)
-    // '{H}-start|middle|end' -> '{H}-start|middle|end' (no change)
-    if (collides.bottom && yAlign === 'bottom') {
+    // ----- COLLIDE WITH BOTTOM EDGE -----
+    // CHANGE
+    // - 'bottom-*'            -> 'top-*'
+    // - '(left|right)-bottom' -> '(left|right)-top'
+    // - '(left|right)-start'  -> '(left|right)-end'
+    //
+    // IGNORE
+    // - 'top-*'
+    // - '{H}-top'
+    // - '{H}-middle'
+    // - '{H}-end'
+    if (collides.bottom && yAlign.match(/bottom|start/)) {
         position = invertPositionVertically(position);
     }
 
-    // COLLIDE LEFT
-    // 'left-*' -> 'right-*' (CHANGE)
-    // '{V}-left' -> '{V}-right' (CHANGE)
-    // 'right-*' -> 'right-*' (no change)
-    // '{V}-right' -> '{V}-right' (no change)
-    // '{V}-start|center|end' -> '{V}-start|center|end' (no change)
-    if (collides.left && xAlign === 'left') {
+    // ----- COLLIDE WITH LEFT EDGE -----
+    // CHANGE
+    // - 'left-*'            -> 'right-*'
+    // - '(top|bottom)-left' -> '(top|bottom)-right'
+    // - '(top|bottom)-end'  -> '(top|bottom)-start'
+    //
+    // IGNORE
+    // - 'right-*'
+    // - '{V}-right'
+    // - '{V}-start'
+    // - '{V}-center'
+    if (collides.left && xAlign.match(/left|end/)) {
         position = invertPositionHorizontally(position);
     }
 
-    // COLLIDE RIGHT
-    // 'right-*' -> 'left-*' (CHANGE)
-    // '{V}-right' -> '{V}-left' (CHANGE)
-    // 'left-*' -> 'left-*' (no change)
-    // '{V}-left' -> '{V}-left' (no change)
-    // '{V}-start|center|end' -> '{V}-start|center|end' (no change)
-    if (collides.right && xAlign === 'right') {
+    // ----- COLLIDE WITH RIGHT EDGE -----
+    // CHANGE
+    // - 'right-*'            -> 'left-*'
+    // - '(top|bottom)-right' -> '(top|bottom)-left'
+    // - '(top|bottom)-start' -> '(top|bottom)-end'
+    //
+    // IGNORE
+    // - 'left-*'
+    // - '(top|bottom)-left'
+    // - '(top|bottom)-center'
+    // - '(top|bottom)-end'
+    if (collides.right && xAlign.match(/right|start/)) {
         position = invertPositionHorizontally(position);
     }
 


### PR DESCRIPTION
Add "start" and "end" alignment support for smart repositioning.

fixes #528

### LGTM's
- [x] Dev LGTM
- [x] Zoom LGTM

### BEFORE
* notice how the menus in the corners extend beyond the viewport
![PixelSnap 2019-08-16 at 16 44 58@2x](https://user-images.githubusercontent.com/545605/63200029-46866500-c045-11e9-9822-4b5be9ae71b4.png)

### AFTER
See https://deploy-preview-530--helix-ui.netlify.com/components/menu/test-positioning.html

* corner menus are properly positioned within the viewport
![PixelSnap 2019-08-16 at 16 43 27@2x](https://user-images.githubusercontent.com/545605/63200031-4d14dc80-c045-11e9-80eb-63aaa5cc99ef.png)
